### PR TITLE
Check for Theme Support of Microformats 2 and act accordingly

### DIFF
--- a/micropub.php
+++ b/micropub.php
@@ -216,13 +216,12 @@ class Micropub {
     if (current_theme_supports('microformats2')) {
       if (isset($_POST['content']) {
         $args['post_content'] = $_POST['content']));
-	}
+      }
     }
     // Else markup the content before passing it through
     else {
       $args['post_content'] = Micropub::generate_post_content();
     }
-   
     return $args;
   }
 

--- a/micropub.php
+++ b/micropub.php
@@ -214,15 +214,14 @@ class Micropub {
     }
     // If the theme declares it supports microformats2, pass the content through
     if(current_theme_supports('microformats2')) {
-	if (isset($_POST['content']))
-	    {
+	if (isset($_POST['content']) {
 		$args['post_content'] = $_POST['content']));
-	    }
-        }
-    // Else markup the content before passing it through
-    else{
-    	$args['post_content'] = Micropub::generate_post_content();
 	}
+    }
+    // Else markup the content before passing it through
+    else {
+    	$args['post_content'] = Micropub::generate_post_content();
+    }
    
     return $args;
   }

--- a/micropub.php
+++ b/micropub.php
@@ -213,14 +213,14 @@ class Micropub {
       }
     }
     // If the theme declares it supports microformats2, pass the content through
-    if(current_theme_supports('microformats2')) {
+    if (current_theme_supports('microformats2')) {
 	if (isset($_POST['content']) {
-		$args['post_content'] = $_POST['content']));
+          $args['post_content'] = $_POST['content']));
 	}
     }
     // Else markup the content before passing it through
     else {
-    	$args['post_content'] = Micropub::generate_post_content();
+      $args['post_content'] = Micropub::generate_post_content();
     }
    
     return $args;

--- a/micropub.php
+++ b/micropub.php
@@ -214,8 +214,8 @@ class Micropub {
     }
     // If the theme declares it supports microformats2, pass the content through
     if (current_theme_supports('microformats2')) {
-	if (isset($_POST['content']) {
-          $args['post_content'] = $_POST['content']));
+      if (isset($_POST['content']) {
+        $args['post_content'] = $_POST['content']));
 	}
     }
     // Else markup the content before passing it through

--- a/micropub.php
+++ b/micropub.php
@@ -54,7 +54,8 @@ class Micropub {
    *
    * @param WP $wp WordPress request context
    *
-   * @uses do_action() Calls 'micropub_request' on the default request
+   * @uses apply_filter() Calls 'before_micropub' on the default request
+   * @uses do_action() Calls 'after_micropub' for additional postprocessing
    */
   public static function parse_query($wp) {
     if (!array_key_exists('micropub', $wp->query_vars)) {
@@ -211,8 +212,18 @@ class Micropub {
         }
       }
     }
-
-    $args['post_content'] = Micropub::generate_post_content();
+    // If the theme declares it supports microformats2, pass the content through
+    if(current_theme_supports('microformats2')) {
+	if (isset($_POST['content']))
+	    {
+		$args['post_content'] = $_POST['content']));
+	    }
+        }
+    // Else markup the content before passing it through
+    else{
+    	$args['post_content'] = Micropub::generate_post_content();
+	}
+   
     return $args;
   }
 


### PR DESCRIPTION
While the filter can override the work done by generate_post_content, the plugin marks up the content in a way that would be an issue if the theme was designed to mark it up already.

To address this, the theme should be able to say it is handling the markup by declaring,
add_theme_support('microformats2'); 

Will concurrently have my starter theme do this and propose same for SemPress.