### PR TITLE
Move Pre and Post Processing Functions to Hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# wordpress-micropub
+# wordpress-micropub [![Circle CI](https://circleci.com/gh/snarfed/wordpress-micropub.svg?style=svg)](https://circleci.com/gh/snarfed/wordpress-micropub)
 
 A [Micropub](http://micropub.net/) server plugin for [WordPress](https://wordpress.org/). Available in the WordPress plugin directory at [wordpress.org/plugins/micropub](https://wordpress.org/plugins/micropub/).
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,15 @@
+# CircleCI automatically reads this file from our repo and uses it for
+# configuration. Docs: https://circleci.com/docs/configuration
+dependencies:
+  cache_directories:
+    - ~/wordpress
+    - ~/wordpress-tests-lib
+  post:
+    - ./bin/install-wp-tests.sh micropub_test ubuntu '' localhost;
+    - sed -i.bak "s/wordpress' );$/wordpress\/' );/" ~/wordpress-tests-lib/wp-tests-config.php
+
+machine:
+  environment:
+    WP_CORE_DIR: $HOME/wordpress
+    WP_TESTS_DIR: $HOME/wordpress-tests-lib
+

--- a/micropub.php
+++ b/micropub.php
@@ -61,6 +61,17 @@ class Micropub {
     add_action('send_headers', array('Micropub', 'http_header'));
     add_filter('host_meta', array('Micropub', 'jrd_links'));
     add_filter('webfinger_data', array('Micropub', 'jrd_links'));
+
+    // Add Markup to Post Content.
+    add_filter('before_micropub', array('Micropub', 'generate_post_content'));
+
+    // Store MF2 as post meta.
+    add_action('after_micropub', array('Micropub', 'store_mf2'));
+    // Sideload any provided photos.
+    add_action('after_micropub', array('Micropub', 'default_file_handler'));
+    // Store geodata in WordPress format.
+    add_action('after_micropub', array('Micropub', 'store_geodata'));
+
   }
 
   /**
@@ -129,7 +140,6 @@ class Micropub {
       kses_remove_filters();  // prevent sanitizing HTML tags in post_content
       $args['ID'] = Micropub::check_error(wp_insert_post($args));
       kses_init_filters();
-      Micropub::postprocess($args['ID']);
       status_header(201);
       header('Location: ' . get_permalink($args['ID']));
 
@@ -145,7 +155,6 @@ class Micropub {
         kses_remove_filters();  // prevent sanitizing HTML tags in post_content
         Micropub::check_error(wp_update_post($args));
         kses_init_filters();
-        Micropub::postprocess($args['ID']);
         status_header(200);
 
       } elseif ($_POST['action'] == 'delete') {
@@ -310,18 +319,12 @@ class Micropub {
         }
       }
     }
-    // If the theme declares it supports microformats2, pass the content through
-    if (current_theme_supports('microformats2')) {
-      if (isset($_POST['content'])) {
-        $args['post_content'] = $_POST['content'];
-      }
-      else if (isset($_POST['summary'])) {
-        $args['post_content'] = $_POST['summary'];
-      }
+    
+    if (isset($_POST['content'])) {
+      $args['post_content'] = $_POST['content'];
     }
-    // Else markup the content before passing it through
-    else {
-      $args['post_content'] = Micropub::generate_post_content();
+    else if (isset($_POST['summary'])) {
+      $args['post_content'] = $_POST['summary'];
     }
     return $args;
   }
@@ -330,8 +333,12 @@ class Micropub {
    * Generates and returns a post_content string suitable for wp_insert_post()
    * and friends.
    */
-  private static function generate_post_content() {
-    $lines = [];
+  public static function generate_post_content($args) {
+    // If the theme declares it supports microformats2 disable this.
+		if (current_theme_supports('microformats2')) {
+      return $args;
+    }
+    $lines = array();
     $verbs = array('like' => 'Likes',
                    'repost' => 'Reposted',
                    'in-reply-to' => 'In reply to');
@@ -367,7 +374,8 @@ class Micropub {
       $lines[] = "\n[gallery size=full columns=1]";
     }
 
-    return implode("\n", $lines);
+    $args['post_content'] = implode("\n", $lines);
+    return $args;
   }
 
   /**
@@ -413,17 +421,23 @@ class Micropub {
   }
 
   /**
-   * Postprocesses a post that has been created or updated. Useful for changes
-   * that require the post id, e.g. uploading media and adding post metadata.
+   * Handles Photo Upload.
+   *
    */
-  private static function postprocess($post_id) {
+  public static function default_file_handler($post_id) {
     if (isset($_FILES['photo'])) {
       require_once(ABSPATH . 'wp-admin/includes/image.php');
       require_once(ABSPATH . 'wp-admin/includes/file.php');
       require_once(ABSPATH . 'wp-admin/includes/media.php');
       Micropub::check_error(media_handle_upload('photo', $post_id));
     }
+  }
 
+  /**
+   * Adds geodata to post.
+   *
+   */
+  private static function store_geodata($post_id) {
     if (isset($_POST['location']) && substr($_POST['location'], 0, 4) == 'geo:') {
       // Geo URI format:
       // http://en.wikipedia.org/wiki/Geo_URI#Example
@@ -435,15 +449,13 @@ class Micropub {
       update_post_meta($post_id, 'geo_latitude', trim($coords[0]));
       update_post_meta($post_id, 'geo_longitude', trim($coords[1]));
     }
-
-    Micropub::store_mf2($post_id);
   }
 
   /**
    * Store properties as post metadata. Details:
    * https://indiewebcamp.com/WordPress_Data#Microformats_data
    */
-  private static function store_mf2($post_id) {
+  public static function store_mf2($post_id) {
     // Do not store access_token or other optional parameters
     $blacklist = array('access_token');
     foreach ($_POST as $key => $value) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,3 +18,5 @@ function _manually_load_plugin() {
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 require $_tests_dir . '/includes/bootstrap.php';
+
+error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_WARNING);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,9 @@
 <?php
 
+error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_WARNING);
+
 define( 'MICROPUB_LOCAL_AUTH', true );
+define( 'WP_DEBUG', false );
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 if ( ! $_tests_dir ) {

--- a/tests/test_micropub.php
+++ b/tests/test_micropub.php
@@ -2,7 +2,7 @@
 
 /** Unit tests for the Micropub class.
  *
- * To test:
+ * TODO:
  * token validation
  * categories/tags
  * post type rendering - reply, like, repost, event, rsvp
@@ -17,12 +17,6 @@ class MicropubTest extends WP_UnitTestCase {
      * @var string
      */
     protected static $status = 0;
-
-    /**
-     * Saved error reporting level
-     * @var int
-     */
-    protected $_error_level = 0;
 
     public static function record_status($header) {
         $matches = array();
@@ -45,15 +39,6 @@ class MicropubTest extends WP_UnitTestCase {
 
         $this->userid = self::factory()->user->create(array('role' => 'editor'));
         wp_set_current_user($this->userid);
-
-        // Suppress "Cannot modify header information - headers already sent by"
-        $this->_error_level = error_reporting();
-        error_reporting($this->_error_level & ~E_WARNING);
-    }
-
-    public function tearDown() {
-        error_reporting($this->_error_level);
-        parent::tearDown();
     }
 
     public function wp_die_handler($message, $title, $args) {

--- a/tests/test_micropub.php
+++ b/tests/test_micropub.php
@@ -108,7 +108,8 @@ class MicropubTest extends WP_UnitTestCase {
         $resp = $this->parse_query();
         $this->assertEquals(201, self::$status);
 
-        $post = wp_get_recent_posts(NULL, OBJECT)[0];
+        $posts = wp_get_recent_posts(NULL, OBJECT);
+        $post = $posts[0];
         $this->assertEquals('publish', $post->post_status);
         $this->assertEquals($this->userid, $post->post_author);
         // check that HTML in content isn't sanitized


### PR DESCRIPTION
This changes the method of removing the generated post content, which I need removed for using Post Kinds, to a removing of a filter over a flag.

At the same time, it allows removing/replacing of upload handling, geodata saving, and mf2 storing to replace with custom functions as needed. 