### PR TITLE
Add Codesniffer file for WordPress Standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,11 @@ To set up your local environment to run the unit tests:
     Time: 703 ms, Memory: 33.75Mb
     OK (1 test, 3 assertions)
     ```
+
+To set up PHPCodesniffer to test changes for adherance to WordPress Coding Standards
+
+1. install [PHPCS](https://github.com/squizlabs/PHP_CodeSniffer).
+1. install and connect [WordPress-Coding-Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards)
+1. Run in command line or install a plugin for your favorite editor.
+1. To list coding standard issues in a file, run phpcs --standard=phpcs.ruleset.xml micropub.php
+1. If you want to try to automatically fix issues, run phpcbf with the same arguments as phpcs.

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<ruleset name="Indieweb-WordPress">
+	<description>Defaults for Indieweb</description>
+	<rule ref="WordPress-Core" />	
+	<rule ref="WordPress-Extra" />
+	<rule ref="WordPress-VIP">
+		<exclude name="WordPress.VIP.FileSystemWritesDisallow" />
+		<exclude name="WordPress.VIP.RestrictedFunctions" />
+		<exclude name="WordPress.VIP.RestrictedVariables" />
+		<exclude name="WordPress.VIP.SuperGlobalInputUsage" />
+		<exclude name="WordPress.VIP.ValidatedSanitizedInput" />
+		<exclude name="WordPress.CSRF.NonceVerification" />
+		<exclude name="WordPress.XSS.EscapeOutput" />
+		<exclude name="WordPress.VIP.PostsPerPage.posts_per_page" />
+	</rule>
+</ruleset>

--- a/readme.txt
+++ b/readme.txt
@@ -99,6 +99,7 @@ TODO
 * Storage of properties now takes place during wp_insert_post
 * Post content will not be automatically marked up if Post Kinds plugin is
   enabled: https://wordpress.org/plugins/indieweb-post-kinds/
+* Add PHP Codesniffer File to continue march toward WordPress Coding Standards
 
 = 0.4 =
 * Store all properties in post meta except those in a blacklist


### PR DESCRIPTION
This is the file @pfefferle set up and I use for checking against WordPress coding standards.