### PR TITLE
Fix Handling of Dates 

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ To set up PHPCodesniffer to test adherence to [WordPress Coding Standards](https
 #### 1.3 (unreleased)
 * Saves [access token response](https://tokens.indieauth.com/) in a post meta field `micropub_auth_response`.
 * Bug fix for `post_date_gmt`
+* Store timezone from published in arguments passed to micropub filter
+* Correctly handle published times that are in a different timezone than the site.
+
 
 #### 1.2 (2017-06-25)
 * Support [OwnYourSwarm](https://ownyourswarm.p3k.io/)'s [custom `checkin` microformats2 property](https://ownyourswarm.p3k.io/docs#checkins), including auto-generating content if necessary.

--- a/micropub.php
+++ b/micropub.php
@@ -479,7 +479,11 @@ class Micropub {
 			$date = new DateTime( $props['published'][0] );
 			// If for whatever reason the date cannot be parsed do not include one which defaults to now
 			if ( $date ) {
-				$date->setTimeZone( new DateTimeZone( get_option( 'timezone_string' ) ) );
+				$tz_string = get_option( 'timezone_string' );
+				if ( empty( $tz_string ) ) {
+					$tz_string = 'GMT';
+				}
+				$date->setTimeZone( new DateTimeZone( $tz_string ) );
 				$tz = $date->getTimezone(); 
 				// Pass this argument to the filter for use
 				$args['timezone'] = $tz->getName();

--- a/micropub.php
+++ b/micropub.php
@@ -481,7 +481,7 @@ class Micropub {
 			if ( $date ) {
 				$tz_string = get_option( 'timezone_string' );
 				if ( empty( $tz_string ) ) {
-					$tz_string = 'GMT';
+					$tz_string = 'UTC';
 				}
 				$date->setTimeZone( new DateTimeZone( $tz_string ) );
 				$tz = $date->getTimezone(); 

--- a/micropub.php
+++ b/micropub.php
@@ -476,8 +476,17 @@ class Micropub {
 		}
 
 		if ( isset( $props['published'] ) ) {
-			$args['post_date'] = iso8601_to_datetime( $props['published'][0] );
-			$args['post_date_gmt'] = get_gmt_from_date( $args['post_date'] );
+			$date = new DateTime( $props['published'][0] );
+			// If for whatever reason the date cannot be parsed do not include one which defaults to now
+			if ( $date ) {
+				$date->setTimeZone( new DateTimeZone( get_option( 'timezone_string' ) ) );
+				$tz = $date->getTimezone(); 
+				// Pass this argument to the filter for use
+				$args['timezone'] = $tz->getName();
+				$args['post_date'] = $date->format( 'Y-m-d H:i:s' );
+				$date->setTimeZone( new DateTimeZone( 'GMT' ) );
+				$args['post_date_gmt'] = $date->format( 'Y-m-d H:i:s' );
+			}
 		}
 
 		// Map micropub categories to WordPress categories if they exist, otherwise

--- a/readme.txt
+++ b/readme.txt
@@ -135,6 +135,8 @@ To set up PHPCodesniffer to test adherence to [WordPress Coding Standards](https
 = 1.3 (unreleased) =
 * Saves [access token response](https://tokens.indieauth.com/) in a post meta field `micropub_auth_response`.
 * Bug fix for `post_date_gmt`
+* Store timezone from published in arguments passed to micropub filter
+* Correctly handle published times that are in a different timezone than the site.
 
 = 1.2 (2017-06-25) =
 * Support [OwnYourSwarm](https://ownyourswarm.p3k.io/)'s [custom `checkin` microformats2 property](https://ownyourswarm.p3k.io/docs#checkins), including auto-generating content if necessary.

--- a/tests/test_micropub.php
+++ b/tests/test_micropub.php
@@ -76,7 +76,7 @@ class MicropubTest extends WP_UnitTestCase {
 		'name' => 'my name',
 		'summary' => 'my summary',
 		'category' => array( 'tag1', 'tag4' ),
-		'published' => '2016-01-01T12:01:23Z',
+		'published' => '2016-01-01T04:01:23-08:00',
 		'location' => 'geo:42.361,-71.092;u=25000',
 	);
 
@@ -89,7 +89,7 @@ class MicropubTest extends WP_UnitTestCase {
 			'name' => array( 'my name' ),
 			'summary' => array( 'my summary' ),
 			'category' => array( 'tag1', 'tag4' ),
-			'published' => array( '2016-01-01T12:01:23Z' ),
+			'published' => array( '2016-01-01T04:01:23-08:00' ),
 			'location' => array( 'geo:42.361,-71.092;u=25000' ),
 		),
 	);
@@ -975,7 +975,7 @@ EOF;
 				'name' => array( 'my name' ),
 				'category' => array( 'tag1', 'tag4', 'add tag' ),
 				'syndication' => array( 'http://synd/1', 'http://synd/2' ),
-				'published' => array( '2016-01-01T12:01:23Z' ),
+				'published' => array( '2016-01-01T04:01:23-08:00' ),
 			) ),
 			$this->query_source( $post->ID ) );
 	}

--- a/tests/test_micropub.php
+++ b/tests/test_micropub.php
@@ -1238,4 +1238,15 @@ EOF;
 		$mf2 = $this->query_source( $post->ID );
 		$this->assertEquals( $input, $mf2);
 	}
+
+	function test_create_with_no_timezone() {
+		Recorder::$request_headers = array( 'content-type' => 'application/json; charset=utf-8' );
+		static::$mf2['properties']['published'] = array( '2016-01-01T12:01:23Z' );
+		Recorder::$input = static::$mf2;
+		Recorder::$micropub_auth_response = static::$micropub_auth_response;
+		self::check_create_basic();
+	}
+
+
+
 }


### PR DESCRIPTION
This addresses the issue of Micropub passing a publish date with a timezone that does not match the one set in WordPress. It also, since it has to parse this anyway, adds the timezone into the arguments passed to wp_insert_post so it can be actioned on filter, specifically for the purpose of a feature in my Simple Location plugin. It can override the displayed timezone, and if this is passed to the filter, I can set the property I need without having to do the calculations a second time.