### PR TITLE
Fixes to Support Indiewebcamp Austin 2017 Hack Day Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ To set up PHPCodesniffer to test adherence to [WordPress Coding Standards](https
 * Bug fix for `post_date_gmt`
 * Store timezone from published in arguments passed to micropub filter
 * Correctly handle published times that are in a different timezone than the site.
-
+* Remove Own Your Swarm override for Post Kinds and Microformats2 and instead shunt the generated content into the excerpt
+* Handle nested properties in bookmarks, likes, replies, and reposts if a name is passed in addition to a URL
 
 #### 1.2 (2017-06-25)
 * Support [OwnYourSwarm](https://ownyourswarm.p3k.io/)'s [custom `checkin` microformats2 property](https://ownyourswarm.p3k.io/docs#checkins), including auto-generating content if necessary.

--- a/readme.txt
+++ b/readme.txt
@@ -137,6 +137,8 @@ To set up PHPCodesniffer to test adherence to [WordPress Coding Standards](https
 * Bug fix for `post_date_gmt`
 * Store timezone from published in arguments passed to micropub filter
 * Correctly handle published times that are in a different timezone than the site.
+* Remove Own Your Swarm override for Post Kinds and Microformats2 and instead shunt the generated content into the excerpt
+* Handle nested properties in bookmarks, likes, replies, and reposts if a name is passed in addition to a URL
 
 = 1.2 (2017-06-25) =
 * Support [OwnYourSwarm](https://ownyourswarm.p3k.io/)'s [custom `checkin` microformats2 property](https://ownyourswarm.p3k.io/docs#checkins), including auto-generating content if necessary.

--- a/tests/test_micropub.php
+++ b/tests/test_micropub.php
@@ -512,30 +512,6 @@ class MicropubTest extends WP_UnitTestCase {
 		$this->assertEquals( '<p>Checked into <a class="h-card p-location" href="http:/a/place">A Place</a>.</p>', $post->post_content );
 	}
 
-	function test_create_checkin_autogenerates_checkin_text_with_content_and_post_kinds() {
-		register_taxonomy( 'kind', 'post' );
-
-		Recorder::$request_headers = array( 'content-type' => 'application/json' );
-		Recorder::$input = array(
-			'type' => array( 'h-entry' ),
-			'properties' => array(
-				'content' => array( 'something' ),
-				'checkin' => array( array(
-					'properties' => array(
-						'name' => array( 'Place' ),
-						'url' => array( 'http://place' ),
-					),
-				) ),
-			),
-		);
-		$post = self::check_create();
-
-		$this->assertEquals( 'Place', get_post_meta( $post->ID, 'geo_address', true ) );
-		$this->assertEquals( "something\n" .
-			'<p>Checked into <a class="h-card p-location" href="http://place">Place</a>.</p>',
-			$post->post_content );
-	}
-
 	function check_create_content_html() {
 		$post = $this->check_create();
 		$this->assertEquals( 'HTML content test', $post->post_title );


### PR DESCRIPTION
* Remove Own Your Swarm Checkin Override
* If Microformats2 enabled theme or Post Kinds, store generated content as a summary/excerpt not content...which is consistent with Microformats and Micropub
* Support nested bookmark, like, repost, etc properties (I intend to come back to this, but this will support what I'm doing for now)