### PR TITLE
Support nested properties in content generation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -155,6 +155,7 @@ into markdown and saved to readme.md.
 * Set minimum version to PHP 5.3
 * Adhere to WordPress Coding Standards
 * Add `micropub_query` filter
+* Support Nested Properties in Content Generation 
 
 
 ### 1.2 (2017-06-25) 

--- a/readme.txt
+++ b/readme.txt
@@ -152,6 +152,7 @@ into markdown and saved to readme.md.
 * Set minimum version to PHP 5.3
 * Adhere to WordPress Coding Standards
 * Add `micropub_query` filter
+* Support Nested Properties in Content Generation 
 
 = 1.2 (2017-06-25) =
 * Support [OwnYourSwarm](https://ownyourswarm.p3k.io/)'s [custom `checkin` microformats2 property](https://ownyourswarm.p3k.io/docs#checkins), including auto-generating content if necessary.

--- a/tests/test_micropub.php
+++ b/tests/test_micropub.php
@@ -935,6 +935,46 @@ EOF
 EOF
 , $post->post_content );
 	}
+	
+	// While the specification allows for nested properties, currently the Post Kinds
+	// plugin hooks into the Micropub plugin to enhance a URL in a like, bookmark, etc.
+	// by parsing the URL and trying to find the page title among other things and adds
+	// it into the input properties.
+	// https://github.com/dshanske/indieweb-post-kinds/blob/master/readme.md
+	function test_create_nested_bookmark() {
+		Recorder::$request_headers = array( 'content-type' => 'application/json' );
+		Recorder::$input = array(
+			'type' => array( 'h-entry' ),
+			'properties' => array(
+				'bookmark-of' => array(
+					'name' => 'Target',
+					'url' => 'http://target'
+				)
+			) );
+		$post = $this->check_create();
+		$this->assertEquals( <<<EOF
+<p>Bookmarked <a class="u-bookmark-of" href="http://target">Target</a>.</p>
+EOF
+, $post->post_content );
+	}
+
+	function test_create_multiple_bookmark_urls() {
+		Recorder::$request_headers = array( 'content-type' => 'application/json' );
+		Recorder::$input = array(
+			'type' => array( 'h-entry' ),
+			'properties' => array(
+				'bookmark-of' => array(
+					'http://target',
+					'http://tarjet'
+				)
+			) );
+		$post = $this->check_create();
+		$this->assertEquals( <<<EOF
+<p>Bookmarked <a class="u-bookmark-of" href="http://target">http://target</a>.</p>
+EOF
+, $post->post_content );
+	}
+
 
 	function test_merges_auto_generated_content() {
 		$_POST = array(


### PR DESCRIPTION
This avoids nested properties from producing phrases like Bookedmarked Array. It adds tests to ensure same. Currently, like the previous version, it does not support multiple URLs in a property for content generation.