### PR TITLE
Add filter for custom query responses

### DIFF
--- a/micropub.php
+++ b/micropub.php
@@ -298,34 +298,37 @@ class Micropub_Plugin {
 	 * @param int $user_id Authenticated User
 	 */
 	private static function query_handler( $user_id ) {
-		switch ( static::$input['q'] ) {
-			case 'config':
-			case 'syndicate-to':
-			case 'mp-syndicate-to':
-				// return empty syndication target with filter
-				$syndicate_tos = apply_filters( 'micropub_syndicate-to', array(), $user_id );
-				$resp          = array( 'syndicate-to' => $syndicate_tos );
-				break;
-			case 'source':
-				$post_id = url_to_postid( static::$input['url'] );
-				if ( ! $post_id ) {
-					static::error( 400, 'not found: ' . static::$input['url'] );
-				}
-				$resp  = static::get_mf2( $post_id );
-				$props = static::$input['properties'];
-				if ( $props ) {
-					if ( ! is_array( $props ) ) {
-						$props = array( $props );
+		$resp = apply_filters( 'micropub_query', null, static::$input );
+		if ( ! $resp ) {
+			switch ( static::$input['q'] ) {
+				case 'config':
+				case 'syndicate-to':
+				case 'mp-syndicate-to':
+					// return empty syndication target with filter
+					$syndicate_tos = apply_filters( 'micropub_syndicate-to', array(), $user_id );
+					$resp          = array( 'syndicate-to' => $syndicate_tos );
+					break;
+				case 'source':
+					$post_id = url_to_postid( static::$input['url'] );
+					if ( ! $post_id ) {
+						static::error( 400, 'not found: ' . static::$input['url'] );
 					}
-					$resp = array(
-						'properties' => array_intersect_key(
-							$resp['properties'], array_flip( $props )
-						),
-					);
-				}
-				break;
-			default:
-				static::error( 400, 'unknown query ' . static::$input['q'] );
+					$resp  = static::get_mf2( $post_id );
+					$props = static::$input['properties'];
+					if ( $props ) {
+						if ( ! is_array( $props ) ) {
+							$props = array( $props );
+						}
+						$resp = array(
+							'properties' => array_intersect_key(
+								$resp['properties'], array_flip( $props )
+							),
+						);
+					}
+					break;
+				default:
+					static::error( 400, 'unknown query ' . static::$input['q'] );
+			}
 		}
 
 		do_action( 'after_micropub', static::$input, null );

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ This project is placed in the public domain. You may also use it under the [CC0 
 
 
 ### Filters and hooks 
-Adds two filters:
+Adds three filters:
 
 `before_micropub( $input )`
 
@@ -30,6 +30,10 @@ Called before handling a Micropub request. Returns `$input`, possibly modified.
 `micropub_syndicate-to( $synd_urls, $user_id )`
 
 Called to generate the list of `syndicate-to` targets to return in response to a query. Returns `$synd_urls`, an array, possibly modified.
+
+`micropub_query( $resp, $input )`
+
+$resp defaults to null. If the return value is non-null, it should be an associative array that is encoded as JSON and will be returned in place of the normal micropub response.
 
 ...and one hook:
 
@@ -150,6 +154,7 @@ into markdown and saved to readme.md.
 * Correctly handle published times that are in a different timezone than the site.
 * Set minimum version to PHP 5.3
 * Adhere to WordPress Coding Standards
+* Add `micropub_query` filter
 
 
 ### 1.2 (2017-06-25) 

--- a/readme.txt
+++ b/readme.txt
@@ -28,7 +28,7 @@ This project is placed in the public domain. You may also use it under the [CC0 
 == WordPress details ==
 
 = Filters and hooks =
-Adds two filters:
+Adds three filters:
 
 `before_micropub( $input )`
 
@@ -37,6 +37,10 @@ Called before handling a Micropub request. Returns `$input`, possibly modified.
 `micropub_syndicate-to( $synd_urls, $user_id )`
 
 Called to generate the list of `syndicate-to` targets to return in response to a query. Returns `$synd_urls`, an array, possibly modified.
+
+`micropub_query( $resp, $input )`
+
+$resp defaults to null. If the return value is non-null, it should be an associative array that is encoded as JSON and will be returned in place of the normal micropub response.
 
 ...and one hook:
 
@@ -147,6 +151,7 @@ into markdown and saved to readme.md.
 * Correctly handle published times that are in a different timezone than the site.
 * Set minimum version to PHP 5.3
 * Adhere to WordPress Coding Standards
+* Add `micropub_query` filter
 
 = 1.2 (2017-06-25) =
 * Support [OwnYourSwarm](https://ownyourswarm.p3k.io/)'s [custom `checkin` microformats2 property](https://ownyourswarm.p3k.io/docs#checkins), including auto-generating content if necessary.

--- a/tests/test_micropub.php
+++ b/tests/test_micropub.php
@@ -256,6 +256,34 @@ class MicropubTest extends WP_UnitTestCase {
 		$this->assertNull( static::$after_micropub_args );
 	}
 
+
+	function test_custom_query() {
+		function custom_query( $return, $input ) {
+			if ( 'abc' === $input['q'] ) {
+				return array( 'abc' => array( '123' ) );
+			}
+			return $return;
+		}
+		add_filter( 'micropub_query', 'custom_query', 10, 2 );
+		$_GET['q'] = 'abc';
+		$expected = array( 'abc' => array( '123' ) );
+		$this->check( 200, $expected );
+
+		$this->assertEquals( $_GET, static::$before_micropub_input );
+		$this->assertEquals( $_GET, static::$after_micropub_input );
+		$this->assertNull( static::$after_micropub_args );
+
+		// Check to ensure default options are still working
+		$_GET['q'] = 'config';
+		$expected = array( 'syndicate-to' => array() );
+		$this->check( 200, $expected );
+
+		$this->assertEquals( $_GET, static::$before_micropub_input );
+		$this->assertEquals( $_GET, static::$after_micropub_input );
+		$this->assertNull( static::$after_micropub_args );
+	}
+
+
 	function test_query_source() {
 		$_POST = self::$post;
 		$post = $this->check_create();


### PR DESCRIPTION
I'd like to be able to allow for custom queries in the event another plugin wants to extend the supported properties and/or add new ones in future.