### PR TITLE
Store Generated Content in Excerpt when Support for Microformats2 or Post Kind is Declared

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -148,6 +148,9 @@ into markdown and saved to readme.md.
 
 
 ### 1.3 (unreleased) 
+* Removes support for custom checkin property(introduced in 1.2) when Post Kinds is enabled or when theme supports microformats2
+* Now generates summary content even when Post Kinds is enabled and the post kind for the property is enabled but stores this as the post excerpt if empty in accordance with the Micropub spec
+* Removes overriding summary content if theme supports microformats2 on basis of fact that no theme actually renders any of these properties as of today. This includes ZenPress, Independent Publisher, SemPress, and the Indieweb fork of TwentySixteen
 * Saves [access token response](https://tokens.indieauth.com/) in a post meta field `micropub_auth_response`.
 * Bug fix for `post_date_gmt`
 * Store timezone from published in arguments passed to micropub filter
@@ -155,7 +158,7 @@ into markdown and saved to readme.md.
 * Set minimum version to PHP 5.3
 * Adhere to WordPress Coding Standards
 * Add `micropub_query` filter
-* Support Nested Properties in Content Generation 
+* Support Nested Properties in Content Generation
 
 
 ### 1.2 (2017-06-25) 

--- a/readme.txt
+++ b/readme.txt
@@ -145,6 +145,9 @@ into markdown and saved to readme.md.
 == Changelog ==
 
 = 1.3 (unreleased) =
+* Removes support for custom checkin property(introduced in 1.2) when Post Kinds is enabled or when theme supports microformats2
+* Now generates summary content even when Post Kinds is enabled and the post kind for the property is enabled but stores this as the post excerpt if empty in accordance with the Micropub spec
+* Removes overriding summary content if theme supports microformats2 on basis of fact that no theme actually renders any of these properties as of today. This includes ZenPress, Independent Publisher, SemPress, and the Indieweb fork of TwentySixteen
 * Saves [access token response](https://tokens.indieauth.com/) in a post meta field `micropub_auth_response`.
 * Bug fix for `post_date_gmt`
 * Store timezone from published in arguments passed to micropub filter
@@ -152,7 +155,7 @@ into markdown and saved to readme.md.
 * Set minimum version to PHP 5.3
 * Adhere to WordPress Coding Standards
 * Add `micropub_query` filter
-* Support Nested Properties in Content Generation 
+* Support Nested Properties in Content Generation
 
 = 1.2 (2017-06-25) =
 * Support [OwnYourSwarm](https://ownyourswarm.p3k.io/)'s [custom `checkin` microformats2 property](https://ownyourswarm.p3k.io/docs#checkins), including auto-generating content if necessary.

--- a/tests/test_micropub.php
+++ b/tests/test_micropub.php
@@ -542,7 +542,7 @@ class MicropubTest extends WP_UnitTestCase {
 
 	function test_create_checkin_autogenerates_checkin_text_with_content_and_post_kinds() {
 		register_taxonomy( 'kind', 'post' );
-
+		update_option( 'kind_termslist', array( 'checkin' ) );
 		Recorder::$request_headers = array( 'content-type' => 'application/json' );
 		Recorder::$input = array(
 			'type' => array( 'h-entry' ),
@@ -559,9 +559,9 @@ class MicropubTest extends WP_UnitTestCase {
 		$post = self::check_create();
 
 		$this->assertEquals( 'Place', get_post_meta( $post->ID, 'geo_address', true ) );
-		$this->assertEquals( "something\n" .
-			'<p>Checked into <a class="h-card p-location" href="http://place">Place</a>.</p>',
-			$post->post_content );
+		$this->assertEquals( '<p>Checked into <a class="h-card p-location" href="http://place">Place</a>.</p>',
+			$post->post_excerpt );
+		$this->assertEquals( 'something', $post->post_content );
 	}
 
 	function check_create_content_html() {
@@ -994,7 +994,7 @@ EOF
 
 	function test_post_kinds_skips_auto_generated_content() {
 		register_taxonomy( 'kind', 'post' );
-
+		update_option( 'kind_termslist', array( 'reply' ) );
 		$_POST = array(
 			'h' => 'entry',
 			'content' => 'foo bar',


### PR DESCRIPTION
This is the other part of the previously closed PR, although I've made some changes to the previous proposal. 

Firstly, the content is generated in 100% of cases, and is stored in the post_excerpt/summary field, unless a summary was already generated by the client. 

This is consistent with the client-side example of  https://www.w3.org/TR/micropub/#unrecognized-properties.

Post Kinds certainly supports rendering, and a theme that declares support for Microformats2 should support the scenario where excerpt is set but content is not, as both are accepted properties.