### PR TITLE
Fix header related issues

### DIFF
--- a/micropub.php
+++ b/micropub.php
@@ -49,7 +49,7 @@ if ( ! defined( 'MICROPUB_DRAFT_MODE' ) ) {
 	define( 'MICROPUB_DRAFT_MODE', '0' );
 }
 
-add_action( 'init', array( 'Micropub_Plugin', 'init' ) );
+add_action( 'plugins_loaded', array( 'Micropub_Plugin', 'init' ) );
 
 /**
  * Micropub Plugin Class
@@ -1093,7 +1093,7 @@ class Micropub_Plugin {
 	}
 
 	public static function header( $header, $value ) {
-		header( $header . ': ' . $value );
+		header( $header . ': ' . $value, false );
 	}
 
 	protected static function get_header( $name ) {


### PR DESCRIPTION
Discovered in working on Indieauth tests that the Micropub plugin wasn't actually sending all of the headers because the replace parameter wasn't set to false. So it was always using the html parameter without anyone noticing up until now.

I'm also going to as part of this, move the firing of the plugin initialization to an earlier hook which fires before the setup_theme hooks, which it should with this type of plugin.