### PR TITLE
Bump Minimum Version Requirements and Initialize Variables

### DIFF
--- a/micropub.php
+++ b/micropub.php
@@ -259,7 +259,7 @@ class Micropub_Plugin {
 
 		// check that we support all requested syndication targets
 		$synd_supported = apply_filters( 'micropub_syndicate-to', array(), $user_id );
-		$synd_requested = static::$input['properties']['syndicate-to'];
+		$synd_requested = isset( static::$input['properties']['syndicate-to'] ) ? static::$input['properties']['syndicate-to'] : array();
 		$unknown        = array_diff( $synd_requested, $synd_supported );
 
 		if ( $unknown ) {

--- a/micropub.php
+++ b/micropub.php
@@ -254,8 +254,8 @@ class Micropub_Plugin {
 	 */
 	public static function post_handler( $user_id ) {
 		$status = 200;
-		$action = static::$input['action'];
-		$url    = static::$input['url'];
+		$action = isset( static::$input['action'] ) ? static::$input['action'] : 'create';
+		$url    = isset( static::$input['url'] ) ? static::$input['url'] : null;
 
 		// check that we support all requested syndication targets
 		$synd_supported = apply_filters( 'micropub_syndicate-to', array(), $user_id );

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Micropub ===
 Contributors: snarfed, dshanske
 Tags: micropub, publish
-Requires at least: 4.4
+Requires at least: 4.7
 Requires PHP: 5.3
-Tested up to: 4.9.1
+Tested up to: 4.9.2
 Stable tag: trunk
 License: CC0
 License URI: http://creativecommons.org/publicdomain/zero/1.0/


### PR DESCRIPTION
This should address #105 and #97 in regards to the initialization of variables and ensuring that the WordPress features in the plugin align with the minimum version they were implemented in.