### PR TITLE
Set default as global default is not working

### DIFF
--- a/micropub.php
+++ b/micropub.php
@@ -84,7 +84,7 @@ class Micropub_Plugin {
 		add_filter( 'webfinger_user_data', array( $cls, 'micropub_jrd_links' ) );
 
 		// Disable adding headers if local auth is set
-		if ( MICROPUB_LOCAL_AUTH  || ! class_exists( 'IndieAuth_Plugin' ) ) {
+		if ( MICROPUB_LOCAL_AUTH || ! class_exists( 'IndieAuth_Plugin' ) ) {
 			add_action( 'wp_head', array( $cls, 'indieauth_html_header' ), 99 );
 			add_action( 'send_headers', array( $cls, 'indieauth_http_header' ) );
 			add_filter( 'host_meta', array( $cls, 'indieauth_jrd_links' ) );
@@ -537,7 +537,7 @@ class Micropub_Plugin {
 			}
 		}
 		if ( ! isset( $props['post-status'] ) ) {
-			return get_option( 'micropub_default_post_status' );
+			return get_option( 'micropub_default_post_status', MICROPUB_DRAFT_MODE ? 'draft' : 'publish' );
 		} else {
 			//  According to the proposed specification these are the only two properties supported.
 			// https://indieweb.org/Micropub-extensions#Post_Status


### PR DESCRIPTION
The global default, set during register_setting, is not working for everyone. So, the pre WordPress 4.7 world, the default would be in the get_option command itself. This reverts to that behavior for now.