### PR TITLE
Add Support for Legacy and New Scopes

### DIFF
--- a/micropub.php
+++ b/micropub.php
@@ -7,7 +7,7 @@
  * Author: Ryan Barrett
  * Author URI: https://snarfed.org/
  * Text Domain: micropub
- * Version: 1.4.1
+ * Version: 1.4.2
  */
 
 /* See README for supported filters and actions.
@@ -63,6 +63,10 @@ class Micropub_Plugin {
 
 	// associative array, populated by authorize().
 	protected static $micropub_auth_response;
+
+
+	// Array of Scopes
+	protected static $scopes;
 
 	/**
 	 * Initialize the plugin.
@@ -166,6 +170,11 @@ class Micropub_Plugin {
 		// Be able to bypass Micropub auth with other auth
 		if ( MICROPUB_LOCAL_AUTH || class_exists( 'IndieAuth_Plugin' ) ) {
 			$user_id = get_current_user_id();
+			// The WordPress IndieAuth plugin uses a global variable named $indieauth_scopes to store this info
+			global $indieauth_scopes;
+			if ( ! empty( $indieauth_scopes ) ) {
+				static::$scopes = $indieauth_scopes;
+			}
 			if ( ! $user_id ) {
 				static::handle_authorize_error( 401, 'Unauthorized' );
 			}
@@ -209,18 +218,18 @@ class Micropub_Plugin {
 			static::handle_authorize_error( 502, "couldn't validate token: " . implode( ' , ', $resp->get_error_messages() ) );
 		}
 
-		$code   = wp_remote_retrieve_response_code( $resp );
-		$body   = wp_remote_retrieve_body( $resp );
-		$params = json_decode( $body, true );
-		$scopes = explode( ' ', $params['scope'] );
+		$code           = wp_remote_retrieve_response_code( $resp );
+		$body           = wp_remote_retrieve_body( $resp );
+		$params         = json_decode( $body, true );
+		static::$scopes = explode( ' ', $params['scope'] );
 
 		if ( (int) ( $code / 100 ) !== 2 ) {
 			static::handle_authorize_error(
 				$code, 'invalid access token: ' . $body
 			);
-		} elseif ( ! in_array( 'post', $scopes, true ) && ! in_array( 'create', $scopes, true ) ) {
+		} elseif ( empty( static::$scopes ) ) {
 			static::handle_authorize_error(
-				401, 'access token is missing post or create scope; got `' . $params['scope'] . '`'
+				401, 'access token is missing scope'
 			);
 		}
 
@@ -244,6 +253,20 @@ class Micropub_Plugin {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Check scope
+	 *
+	 * @param string $scope
+	 *
+	 * @return boolean
+	**/
+	protected static function check_scope( $scope ) {
+		if ( in_array( 'post', static::$scopes, true ) ) {
+			return true;
+		}
+		return in_array( $scope, static::$scopes, true );
 	}
 
 	/**
@@ -282,7 +305,10 @@ class Micropub_Plugin {
 	public static function post_handler( $user_id ) {
 		$status = 200;
 		$action = self::get( static::$input, 'action', 'create' );
-		$url    = self::get( static::$input, 'url' );
+		if ( ! self::check_scope( $action ) ) {
+			static::error( 403, sprintf( 'scope insufficient to %1$s posts', $action ) );
+		}
+		$url = self::get( static::$input, 'url' );
 
 		// check that we support all requested syndication targets
 		$synd_supported = apply_filters( 'micropub_syndicate-to', array(), $user_id );
@@ -369,9 +395,14 @@ class Micropub_Plugin {
 					$resp          = array( 'syndicate-to' => $syndicate_tos );
 					break;
 				case 'category':
-					$resp = array_merge( 
-						get_tags( array( 'fields' => 'names' ) ), 
-						get_terms( array( 'taxonomy' => 'category', 'fields' => 'names' ) ) 
+					$resp = array_merge(
+						get_tags( array( 'fields' => 'names' ) ),
+						get_terms(
+							array(
+								'taxonomy' => 'category',
+								'fields'   => 'names',
+							)
+						)
 					);
 					break;
 				case 'source':

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,18 @@ Supports the [full W3C Micropub CR spec](https://www.w3.org/TR/micropub/) as of 
 This project is placed in the public domain. You may also use it under the [CC0 license](http://creativecommons.org/publicdomain/zero/1.0/).
 
 
+## Scope 
+
+Supports the following [scope](https://indieweb.org/scope) parameters requested by Micropub clients.
+* post (legacy) - Grants all user delegated access
+* create - Allows the client to create posts on behalf of the user
+* update - Allows the client to update posts on behalf of the user
+* delete - Allows the client to delete posts on behalf of the user
+* indelete - Allows the client to undelete posts on behalf of the user
+
+Does not currently support the 'media' scope due lack of adoption by clients. At this time, create or update grants permission for file uploads.
+
+
 ## WordPress details 
 
 
@@ -169,6 +181,10 @@ into markdown and saved to readme.md.
 
 
 ## Changelog 
+
+
+### 1.4.2 (2018-04-19) 
+* Enforce scopes
 
 
 ### 1.4.1 (2018-04-15) 

--- a/readme.txt
+++ b/readme.txt
@@ -25,6 +25,17 @@ Supports the [full W3C Micropub CR spec](https://www.w3.org/TR/micropub/) as of 
 
 This project is placed in the public domain. You may also use it under the [CC0 license](http://creativecommons.org/publicdomain/zero/1.0/).
 
+== Scope ==
+
+Supports the following [scope](https://indieweb.org/scope) parameters requested by Micropub clients.
+* post (legacy) - Grants all user delegated access
+* create - Allows the client to create posts on behalf of the user
+* update - Allows the client to update posts on behalf of the user
+* delete - Allows the client to delete posts on behalf of the user
+* indelete - Allows the client to undelete posts on behalf of the user
+
+Does not currently support the 'media' scope due lack of adoption by clients. At this time, create or update grants permission for file uploads.
+
 == WordPress details ==
 
 = Filters and hooks =
@@ -167,6 +178,9 @@ To automatically convert the readme.txt file to readme.md, you may, if you have 
 into markdown and saved to readme.md.
 
 == Changelog ==
+
+= 1.4.2 (2018-04-19) =
+* Enforce scopes
 
 = 1.4.1 (2018-04-15) =
 * Version bump due some individuals not getting template file


### PR DESCRIPTION
Right now the plugin completely ignores scopes. This gives it support for current and future scopes.