### PR TITLE
Improve Spec Compliance

### DIFF
--- a/micropub.php
+++ b/micropub.php
@@ -286,9 +286,13 @@ class Micropub_Plugin {
 
 		// check that we support all requested syndication targets
 		$synd_supported = apply_filters( 'micropub_syndicate-to', array(), $user_id );
+		$uids           = array();
+		foreach ( $synd_supported as $syn ) {
+			$uids[] = self::get( $syn, 'uid' );
+		}
 		$properties     = self::get( static::$input, 'properties' );
 		$synd_requested = self::get( $properties, 'syndicate-to' );
-		$unknown        = array_diff( $synd_requested, $synd_supported );
+		$unknown        = array_diff( $synd_requested, $uids );
 
 		if ( $unknown ) {
 			static::error( 400, 'Unknown syndicate-to targets: ' . implode( ', ', $unknown ) );

--- a/micropub.php
+++ b/micropub.php
@@ -612,7 +612,7 @@ class Micropub_Plugin {
 		$args  = array();
 
 		foreach ( array(
-			'slug'    => 'post_name',
+			'mp-slug' => 'post_name',
 			'name'    => 'post_title',
 			'summary' => 'post_excerpt',
 		) as $mf => $wp ) {

--- a/micropub.php
+++ b/micropub.php
@@ -291,11 +291,11 @@ class Micropub_Plugin {
 			$uids[] = self::get( $syn, 'uid' );
 		}
 		$properties     = self::get( static::$input, 'properties' );
-		$synd_requested = self::get( $properties, 'syndicate-to' );
+		$synd_requested = self::get( $properties, 'mp-syndicate-to' );
 		$unknown        = array_diff( $synd_requested, $uids );
 
 		if ( $unknown ) {
-			static::error( 400, 'Unknown syndicate-to targets: ' . implode( ', ', $unknown ) );
+			static::error( 400, 'Unknown mp-syndicate-to targets: ' . implode( ', ', $unknown ) );
 
 		} elseif ( ! $url || 'create' === $action ) { // create
 			if ( $user_id && ! user_can( $user_id, 'publish_posts' ) ) {
@@ -362,7 +362,6 @@ class Micropub_Plugin {
 			switch ( static::$input['q'] ) {
 				case 'config':
 				case 'syndicate-to':
-				case 'mp-syndicate-to':
 					// return empty syndication target with filter
 					$syndicate_tos = apply_filters( 'micropub_syndicate-to', array(), $user_id );
 					$resp          = array( 'syndicate-to' => $syndicate_tos );

--- a/tests/test_micropub.php
+++ b/tests/test_micropub.php
@@ -72,7 +72,7 @@ class MicropubTest extends WP_UnitTestCase {
 	protected static $post = array(
 		'h' => 'entry',
 		'content' => 'my<br>content',
-		'slug' => 'my_slug',
+		'mp-slug' => 'my_slug',
 		'name' => 'my name',
 		'summary' => 'my summary',
 		'category' => array( 'tag1', 'tag4' ),
@@ -85,7 +85,7 @@ class MicropubTest extends WP_UnitTestCase {
 		'type' => array( 'h-entry' ),
 		'properties' => array(
 			'content' => array( 'my<br>content' ),
-			'slug' => array( 'my_slug' ),
+			'mp-slug' => array( 'my_slug' ),
 			'name' => array( 'my name' ),
 			'summary' => array( 'my summary' ),
 			'category' => array( 'tag1', 'tag4' ),
@@ -1056,7 +1056,7 @@ EOF;
 			'type' => array( 'h-entry' ),
 			'properties' => array(
 				'content' => array( 'new<br>content' ),
-				'slug' => array( 'my_slug' ),
+				'mp-slug' => array( 'my_slug' ),
 				'name' => array( 'my name' ),
 				'category' => array( 'tag1', 'tag4', 'add tag' ),
 				'syndication' => array( 'http://synd/1', 'http://synd/2' ),

--- a/tests/test_micropub.php
+++ b/tests/test_micropub.php
@@ -374,7 +374,14 @@ class MicropubTest extends WP_UnitTestCase {
 	}
 
 	public static function syndications( $synd_urls, $user_id ) {
-		return array( 'instagram', 'twitter' );
+		return array( 
+			array(
+			       	'name' => 'Instagram',
+				'uid' => 'instagram'),
+			array(
+				'name' => 'Twitter',
+				'uid' => 'twitter' )
+		);
 	}
 
 	function test_create_with_supported_syndicate_to() {

--- a/tests/test_micropub.php
+++ b/tests/test_micropub.php
@@ -389,7 +389,7 @@ class MicropubTest extends WP_UnitTestCase {
 
 		Recorder::$request_headers = array( 'content-type' => 'application/json; charset=utf-8' );
 		Recorder::$input = static::$mf2;
-		Recorder::$input['properties']['syndicate-to'] = array( 'twitter' );
+		Recorder::$input['properties']['mp-syndicate-to'] = array( 'twitter' );
 		Recorder::$micropub_auth_response = static::$micropub_auth_response;
 
 		self::check_create();
@@ -400,10 +400,10 @@ class MicropubTest extends WP_UnitTestCase {
 
 		Recorder::$request_headers = array( 'content-type' => 'application/json; charset=utf-8' );
 		Recorder::$input = static::$mf2;
-		Recorder::$input['properties']['syndicate-to'] = array( 'twitter', 'facebook' );
+		Recorder::$input['properties']['mp-syndicate-to'] = array( 'twitter', 'facebook' );
 		Recorder::$micropub_auth_response = static::$micropub_auth_response;
 
-		$this->check( 400, 'Unknown syndicate-to targets: facebook' );
+		$this->check( 400, 'Unknown mp-syndicate-to targets: facebook' );
 	}
 
 	function test_create_content_html_post() {


### PR DESCRIPTION
https://www.w3.org/TR/micropub/#syndication-targets-p-4

Syndication targets must have a UID and a Name. 

https://www.w3.org/TR/micropub/#examples-of-creating-objects-p-4

Property should be mp-syndicate-to not syndicate-to. 

https://www.w3.org/TR/micropub/#syndication-targets

The query only is syndicate-to 

https://indieweb.org/Micropub-extensions

The extension for slug is mp-slug at the moment. Updating to comply with same. 