### PR TITLE
Add support for querying categories

### DIFF
--- a/micropub.php
+++ b/micropub.php
@@ -366,6 +366,12 @@ class Micropub_Plugin {
 					$syndicate_tos = apply_filters( 'micropub_syndicate-to', array(), $user_id );
 					$resp          = array( 'syndicate-to' => $syndicate_tos );
 					break;
+				case 'category':
+					$resp = array_merge( 
+						get_tags( array( 'fields' => 'names' ) ), 
+						get_terms( array( 'taxonomy' => 'category', 'fields' => 'names' ) ) 
+					);
+					break;
 				case 'source':
 					$post_id = url_to_postid( static::$input['url'] );
 					if ( ! $post_id ) {

--- a/tests/test_micropub.php
+++ b/tests/test_micropub.php
@@ -293,6 +293,18 @@ class MicropubTest extends WP_UnitTestCase {
 		$this->check( 200, self::$mf2 );
 	}
 
+	function test_query_category() {
+		$_POST = self::$post;
+		$post = $this->check_create();
+		$_GET = array(
+			'q' => 'category'
+		);
+		wp_set_post_tags( $post->ID, 'Tag' );
+		wp_create_categories( array( 'Category' ), $post->ID );
+		$this->check( 200, array( 'Tag', 'Category' ) );
+	}
+
+
 	function test_query_source_with_properties() {
 		$_POST = self::$post;
 		$post = $this->check_create();


### PR DESCRIPTION
This returns a merged list of tags and categories if q=category is sent to the endpoint.