### PR TITLE
Add syndication hook

### DIFF
--- a/micropub.php
+++ b/micropub.php
@@ -346,7 +346,9 @@ class Micropub_Plugin {
 		} else {
 			static::error( 400, 'unknown action ' . $action );
 		}
-
+		if ( ! empty( $synd_requested ) ) {
+			do_action( 'micropub_syndication', $args['ID'], $synd_requested );
+		}
 		do_action( 'after_micropub', static::$input, $args );
 		static::respond( $status, null, $args );
 	}

--- a/readme.md
+++ b/readme.md
@@ -39,11 +39,15 @@ Called to generate the list of `syndicate-to` targets to return in response to a
 
 $resp defaults to null. If the return value is non-null, it should be an associative array that is encoded as JSON and will be returned in place of the normal micropub response.
 
-...and one hook:
+...and two hooks:
 
 `after_micropub( $input, $wp_args = null)`
 
 Called after handling a Micropub request. Not called if the request fails (ie doesn't return HTTP 2xx).
+
+`micropub_syndication( $ID, $syndicate_to )`
+
+Called only if there are syndication targets $syndicate_to for post $ID. $syndicate_to will be an array of UIDs that are verified as one or more of the UIDs added using the `micropub_syndicate-to` filter.
 
 Arguments:
 
@@ -174,6 +178,7 @@ into markdown and saved to readme.md.
 * MICROPUB_LOCAL_AUTH now disables adding auth headers to the page.
 * Fix post status issue by checking for valid defaults
 * Add configuration option under writing settings to set default post status
+* Add `micropub_syndication` hook that only fires on a request to syndicate to make it easier for third-party plugins to hook in
 
 
 ### 1.3 (2017-12-31) 

--- a/readme.txt
+++ b/readme.txt
@@ -46,11 +46,15 @@ Called to generate the list of `syndicate-to` targets to return in response to a
 
 $resp defaults to null. If the return value is non-null, it should be an associative array that is encoded as JSON and will be returned in place of the normal micropub response.
 
-...and one hook:
+...and two hooks:
 
 `after_micropub( $input, $wp_args = null)`
 
 Called after handling a Micropub request. Not called if the request fails (ie doesn't return HTTP 2xx).
+
+`micropub_syndication( $ID, $syndicate_to )`
+
+Called only if there are syndication targets $syndicate_to for post $ID. $syndicate_to will be an array of UIDs that are verified as one or more of the UIDs added using the `micropub_syndicate-to` filter.
 
 Arguments:
 
@@ -171,6 +175,7 @@ into markdown and saved to readme.md.
 * MICROPUB_LOCAL_AUTH now disables adding auth headers to the page.
 * Fix post status issue by checking for valid defaults
 * Add configuration option under writing settings to set default post status
+* Add `micropub_syndication` hook that only fires on a request to syndicate to make it easier for third-party plugins to hook in
 
 = 1.3 (2017-12-31) =
 * Saves [access token response](https://tokens.indieauth.com/) in a post meta field `micropub_auth_response`.

--- a/tests/test_micropub.php
+++ b/tests/test_micropub.php
@@ -406,6 +406,22 @@ class MicropubTest extends WP_UnitTestCase {
 		$this->check( 400, 'Unknown mp-syndicate-to targets: facebook' );
 	}
 
+	function syndicate_trigger( $id, $syns ) {
+		add_post_meta( $id, 'testing', $syns );
+	}
+
+	function test_create_syn_hook() {
+		add_filter( 'micropub_syndicate-to', array( $this, 'syndications' ) );
+		add_action( 'micropub_syndication', array( $this, 'syndicate_trigger' ), 10, 2 );
+		Recorder::$request_headers = array( 'content-type' => 'application/json; charset=utf-8' );
+		Recorder::$input = static::$mf2;
+		Recorder::$input['properties']['mp-syndicate-to'] = array( 'twitter' );
+		Recorder::$micropub_auth_response = static::$micropub_auth_response;
+		$post = self::check_create();
+		$this->assertEquals( array( 'twitter' ), get_post_meta( $post->ID, 'testing', true ) );		
+	}
+
+
 	function test_create_content_html_post() {
 		$_POST = array(
 			'h' => 'entry',


### PR DESCRIPTION
This PR adds a hook that only fires if there are verified syndication requests. This makes it easier for a third-party plugin to hook in, rather than the more generic after_micropub which covers everything.

The goal is to be able to say to a POSSE plugin developer, add your service to this filter, and trigger POSSE on this action. 