### PR TITLE
Pull token data from IndieAuth plugin

### DIFF
--- a/micropub.php
+++ b/micropub.php
@@ -64,7 +64,6 @@ class Micropub_Plugin {
 	// associative array, populated by authorize().
 	protected static $micropub_auth_response;
 
-
 	// Array of Scopes
 	protected static $scopes;
 
@@ -174,6 +173,10 @@ class Micropub_Plugin {
 			global $indieauth_scopes;
 			if ( ! empty( $indieauth_scopes ) ) {
 				static::$scopes = $indieauth_scopes;
+			}
+			global $indieauth_token;
+			if ( ! empty( $indieauth_token ) ) {
+				static::$micropub_auth_response = $indieauth_token;
 			}
 			if ( ! $user_id ) {
 				static::handle_authorize_error( 401, 'Unauthorized' );

--- a/micropub.php
+++ b/micropub.php
@@ -169,15 +169,11 @@ class Micropub_Plugin {
 		// Be able to bypass Micropub auth with other auth
 		if ( MICROPUB_LOCAL_AUTH || class_exists( 'IndieAuth_Plugin' ) ) {
 			$user_id = get_current_user_id();
-			// The WordPress IndieAuth plugin uses a global variable named $indieauth_scopes to store this info
-			global $indieauth_scopes;
-			if ( ! empty( $indieauth_scopes ) ) {
-				static::$scopes = $indieauth_scopes;
-			}
-			global $indieauth_token;
-			if ( ! empty( $indieauth_token ) ) {
-				static::$micropub_auth_response = $indieauth_token;
-			}
+
+			// The WordPress IndieAuth plugin uses filters for this
+			static::$scopes = apply_filters( 'indieauth_scopes', null );
+			static::$micropub_auth_response = apply_filters( 'indieauth_response',  null );
+			
 			if ( ! $user_id ) {
 				static::handle_authorize_error( 401, 'Unauthorized' );
 			}

--- a/micropub.php
+++ b/micropub.php
@@ -7,7 +7,7 @@
  * Author: Ryan Barrett
  * Author URI: https://snarfed.org/
  * Text Domain: micropub
- * Version: 1.4.2
+ * Version: 1.4.3
  */
 
 /* See README for supported filters and actions.

--- a/readme.md
+++ b/readme.md
@@ -183,6 +183,11 @@ into markdown and saved to readme.md.
 ## Changelog 
 
 
+### 1.4.3 (2018-05-27) 
+* Change scopes to filter
+* Get token response when IndieAuth plugin is installed
+
+
 ### 1.4.2 (2018-04-19) 
 * Enforce scopes
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: snarfed, dshanske
 Tags: micropub, publish
 Requires at least: 4.7
 Requires PHP: 5.3
-Tested up to: 4.9.5
+Tested up to: 4.9.6
 Stable tag: trunk
 License: CC0
 License URI: http://creativecommons.org/publicdomain/zero/1.0/
@@ -178,6 +178,10 @@ To automatically convert the readme.txt file to readme.md, you may, if you have 
 into markdown and saved to readme.md.
 
 == Changelog ==
+
+= 1.4.3 (2018-05-27) =
+* Change scopes to filter
+* Get token response when IndieAuth plugin is installed
 
 = 1.4.2 (2018-04-19) =
 * Enforce scopes


### PR DESCRIPTION
I noticed that when I use the IndieAuth endpoint, the auth response storage vanished. This restores that behavior.