### PR TITLE
Return empty json not empty string

### DIFF
--- a/micropub.php
+++ b/micropub.php
@@ -1218,7 +1218,7 @@ class Micropub_Plugin {
 	protected static function respond( $code, $resp = null, $args = null ) {
 		status_header( $code );
 		static::header( 'Content-Type', 'application/json' );
-		exit( $resp ? wp_json_encode( $resp ) : '' );
+		exit( $resp ? wp_json_encode( $resp ) : '{}' );
 	}
 
 	public static function header( $header, $value ) {


### PR DESCRIPTION
If returning a json body, it should be an empty JSON.