### PR TITLE
Split off Authorization

### DIFF
--- a/includes/class-micropub-authorize.php
+++ b/includes/class-micropub-authorize.php
@@ -165,7 +165,9 @@ class Micropub_Authorize {
 		// look for a user with the same url as the token's `me` value.
 		$user = static::user_url( $me );
 
-		// IndieAuth Plugin uses priority 9		
+		// IndieAuth Plugin uses priority 9
+		// TODO: These filters are added here to ensure that they are loaded after the scope is set
+		// However future changes will change the order so this is no longer needed
 		add_filter( 'indieauth_scopes', array( $cls, 'indieauth_scopes' ), 11 );
 		add_filter( 'indieauth_response', array( $cls, 'indieauth_response' ), 11 );
 

--- a/includes/class-micropub-authorize.php
+++ b/includes/class-micropub-authorize.php
@@ -19,11 +19,11 @@ add_action( 'plugins_loaded', array( 'Micropub_Authorize', 'init' ) );
  */
 class Micropub_Authorize {
 
-	// associative array, populated by authorize().
-	protected static $micropub_auth_response;
+	// associative array, populated by determine_current_user.
+	protected static $micropub_auth_response = array();
 
 	// Array of Scopes
-	protected static $scopes;
+	protected static $scopes = array();
 
 	/**
 	 * Initialize the plugin.
@@ -37,6 +37,10 @@ class Micropub_Authorize {
 		add_filter( 'webfinger_user_data', array( $cls, 'jrd_links' ) );
 		// The WordPress IndieAuth plugin uses priority 30
 		add_filter( 'determine_current_user', array( $cls, 'determine_current_user' ), 31 );
+
+		// IndieAuth Plugin uses priority 9		
+		add_filter( 'indieauth_scopes', array( $cls, 'indieauth_scopes' ), 11 );
+		add_filter( 'indieauth_response', array( $cls, 'indieauth_response' ), 11 );
 	}
 
 	public static function indieauth_scopes( $scopes ) {
@@ -119,7 +123,7 @@ class Micropub_Authorize {
 			return $user_id;
 		}
 
-		// Only try to authenticate if this is the Micropub endpoint
+		// Since this runs on the built-in determine_current user filter only try to authenticate if this is the Micropub endpoint
 		if ( ! empty( get_query_var( 'micropub' ) ) ) {
 			return $user_id;
 		}
@@ -164,8 +168,6 @@ class Micropub_Authorize {
 		// look for a user with the same url as the token's `me` value.
 		$user = static::user_url( $me );
 
-		add_filter( 'indieauth_scopes', array( $cls, 'indieauth_scopes' ), 11 );
-		add_filter( 'indieauth_response', array( $cls, 'indieauth_response' ), 11 );
 		if ( $user ) {
 			return $user;
 		}

--- a/includes/class-micropub-authorize.php
+++ b/includes/class-micropub-authorize.php
@@ -1,0 +1,218 @@
+<?php
+
+/* For debugging purposes this will bypass Micropub authentication
+ * in favor of WordPress authentication
+ * Using this to test querying(q=) parameters quickly
+ */
+// Allows for a custom Authentication and Token Endpoint
+if ( ! defined( 'MICROPUB_AUTHENTICATION_ENDPOINT' ) ) {
+	define( 'MICROPUB_AUTHENTICATION_ENDPOINT', 'https://indieauth.com/auth' );
+}
+if ( ! defined( 'MICROPUB_TOKEN_ENDPOINT' ) ) {
+	define( 'MICROPUB_TOKEN_ENDPOINT', 'https://tokens.indieauth.com/token' );
+}
+
+add_action( 'plugins_loaded', array( 'Micropub_Authorize', 'init' ) );
+
+/**
+ * Micropub IndieAuth Authorization Class
+ */
+class Micropub_Authorize {
+
+	// associative array, populated by authorize().
+	protected static $micropub_auth_response;
+
+	// Array of Scopes
+	protected static $scopes;
+
+	/**
+	 * Initialize the plugin.
+	 */
+	public static function init() {
+		$cls = get_called_class();
+
+		add_action( 'wp_head', array( $cls, 'html_header' ), 99 );
+		add_action( 'send_headers', array( $cls, 'http_header' ) );
+		add_filter( 'host_meta', array( $cls, 'jrd_links' ) );
+		add_filter( 'webfinger_user_data', array( $cls, 'jrd_links' ) );
+		// The WordPress IndieAuth plugin uses priority 30
+		add_filter( 'determine_current_user', array( $cls, 'determine_current_user' ), 31 );
+	}
+
+	public static function indieauth_scopes( $scopes ) {
+		return static::$scopes;
+	}
+	public static function indieauth_response( $response ) {
+		return static::$micropub_auth_response;
+	}
+
+	public static function header( $header, $value ) {
+			header( $header . ': ' . $value, false );
+	}
+
+	public static function http_header() {
+			static::header( 'Link', '<' . get_option( 'indieauth_authorization_endpoint', MICROPUB_AUTHENTICATION_ENDPOINT ) . '>; rel="authorization_endpoint"' );
+			static::header( 'Link', '<' . get_option( 'indieauth_token_endpoint', MICROPUB_TOKEN_ENDPOINT ) . '>; rel="token_endpoint"' );
+	}
+	public static function html_header() {
+			printf( '<link rel="authorization_endpoint" href="%s" />' . PHP_EOL, get_option( 'indieauth_authorization_endpoint', MICROPUB_AUTHENTICATION_ENDPOINT ) );
+			printf( '<link rel="token_endpoint" href="%s" />' . PHP_EOL, get_option( 'indieauth_token_endpoint', MICROPUB_TOKEN_ENDPOINT ) );
+	}
+
+	public static function jrd_links( $array ) {
+		$array['links'][] = array(
+			'rel'  => 'authorization_endpoint',
+			'href' => get_option( 'indieauth_authorization_endpoint', MICROPUB_AUTHENTICATION_ENDPOINT ),
+		);
+		$array['links'][] = array(
+			'rel'  => 'token_endpoint',
+			'href' => get_option( 'indieauth_token_endpoint', MICROPUB_TOKEN_ENDPOINT ),
+		);
+
+		return $array;
+	}
+
+	public static function get( $array, $key, $default = array() ) {
+		if ( is_array( $array ) ) {
+			return isset( $array[ $key ] ) ? $array[ $key ] : $default;
+		}
+		return $default;
+	}
+
+	/**
+	 * Get the authorization header
+	 *
+	 * On certain systems and configurations, the Authorization header will be
+	 * stripped out by the server or PHP. Typically this is then used to
+	 * generate `PHP_AUTH_USER`/`PHP_AUTH_PASS` but not passed on. We use
+	 * `getallheaders` here to try and grab it out instead.
+	 *
+	 * @return string|null Authorization header if set, null otherwise
+	 */
+	public static function get_authorization_header() {
+		if ( ! empty( $_SERVER['HTTP_AUTHORIZATION'] ) ) {
+			return wp_unslash( $_SERVER['HTTP_AUTHORIZATION'] );
+		}
+		// When Apache speaks via FastCGI with PHP, then the authorization header is often available as REDIRECT_HTTP_AUTHORIZATION.
+		if ( ! empty( $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ) ) {
+			return wp_unslash( $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] );
+		}
+		$headers = getallheaders();
+		// Check for the authorization header case-insensitively
+		foreach ( $headers as $key => $value ) {
+			if ( strtolower( $key ) === 'authorization' ) {
+				return $value;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Validate the access token at the token endpoint.
+	 *
+	 * https://indieauth.spec.indieweb.org/#access-token-verification
+	 */
+	public static function determine_current_user( $user_id ) {
+		$cls = get_called_class();
+		// Do not try to find a user if one has already been found
+		if ( ! empty( $user_id ) ) {
+			return $user_id;
+		}
+
+		// Only try to authenticate if this is the Micropub endpoint
+		if ( ! empty( get_query_var( 'micropub' ) ) ) {
+			return $user_id;
+		}
+
+		// find the access token
+		$auth  = static::get_authorization_header();
+		$token = self::get( $_POST, 'access_token' );
+		if ( ! $auth && ! $token ) {
+			static::authorize_error( 401, 'missing access token' );
+		}
+
+		$resp = wp_remote_get(
+			get_option( 'indieauth_token_endpoint', MICROPUB_TOKEN_ENDPOINT ), array(
+				'headers' => array(
+					'Accept'        => 'application/json',
+					'Authorization' => $auth ?: 'Bearer ' . $token,
+				),
+			)
+		);
+		if ( is_wp_error( $resp ) ) {
+			return $resp;
+		}
+
+		$code           = wp_remote_retrieve_response_code( $resp );
+		$body           = wp_remote_retrieve_body( $resp );
+		$params         = json_decode( $body, true );
+		static::$scopes = explode( ' ', $params['scope'] );
+
+		if ( (int) ( $code / 100 ) !== 2 ) {
+			return static::authorize_error(
+				$code, 'invalid access token: ' . $body
+			);
+		} elseif ( empty( static::$scopes ) ) {
+			return static::authorize_error(
+				401, 'access token is missing scope'
+			);
+		}
+
+		$me                             = untrailingslashit( $params['me'] );
+		static::$micropub_auth_response = $params;
+
+		// look for a user with the same url as the token's `me` value.
+		$user = static::user_url( $me );
+
+		add_filter( 'indieauth_scopes', array( $cls, 'indieauth_scopes' ), 11 );
+		add_filter( 'indieauth_response', array( $cls, 'indieauth_response' ), 11 );
+		if ( $user ) {
+			return $user;
+		}
+
+		// no user with that url. if the token is for this site itself, allow it and
+		// post as the default user
+		$home = untrailingslashit( home_url() );
+		if ( $home !== $me ) {
+			return $user_id;
+		}
+		return $user;
+	}
+
+	private static function authorize_error( $code, $msg ) {
+		return new WP_Error(
+			'forbidden',
+			$msg,
+			array(
+				'status' => $code
+			)
+		);
+	}
+
+	/**
+	 * Try to match a user with a URL with or without trailing slash.
+	 *
+	 * @param string $me URL to match
+	 *
+	 * @return null|int Return user ID if matched or null
+	**/
+	public static function user_url( $me ) {
+		if ( ! isset( $me ) ) {
+			return null;
+		}
+		$search = array(
+			'search'         => $me,
+			'search_columns' => array( 'url' ),
+		);
+		$users  = get_users( $search );
+
+		$search['search'] = $me . '/';
+		$users            = array_merge( $users, get_users( $search ) );
+		foreach ( $users as $user ) {
+			if ( untrailingslashit( $user->user_url ) === $me ) {
+				return $user->ID;
+			}
+		}
+		return null;
+	}
+}

--- a/includes/class-micropub-authorize.php
+++ b/includes/class-micropub-authorize.php
@@ -173,13 +173,7 @@ class Micropub_Authorize {
 			return $user;
 		}
 
-		// no user with that url. if the token is for this site itself, allow it and
-		// post as the default user
-		$home = untrailingslashit( home_url() );
-		if ( $home !== $me ) {
-			return $user_id;
-		}
-		return $user;
+		return $user_id;
 	}
 
 	private static function authorize_error( $code, $msg ) {

--- a/includes/class-micropub-authorize.php
+++ b/includes/class-micropub-authorize.php
@@ -129,7 +129,7 @@ class Micropub_Authorize {
 		$auth  = static::get_authorization_header();
 		$token = self::get( $_POST, 'access_token' );
 		if ( ! $auth && ! $token ) {
-			static::authorize_error( 401, 'missing access token' );
+			return static::authorize_error( 401, 'missing access token' );
 		}
 
 		$resp = wp_remote_get(

--- a/includes/class-micropub-authorize.php
+++ b/includes/class-micropub-authorize.php
@@ -121,7 +121,8 @@ class Micropub_Authorize {
 		}
 
 		// Since this runs on the built-in determine_current user filter only try to authenticate if this is the Micropub endpoint
-		if ( ! empty( get_query_var( 'micropub' ) ) ) {
+		$micropub = get_query_var( 'micropub' );
+		if ( empty( $micropub ) ) {
 			return $user_id;
 		}
 
@@ -163,7 +164,7 @@ class Micropub_Authorize {
 		static::$micropub_auth_response = $params;
 
 		// look for a user with the same url as the token's `me` value.
-		$user = static::user_url( $me );
+		$user_id = static::user_url( $me );
 
 		// IndieAuth Plugin uses priority 9
 		// TODO: These filters are added here to ensure that they are loaded after the scope is set
@@ -171,11 +172,11 @@ class Micropub_Authorize {
 		add_filter( 'indieauth_scopes', array( $cls, 'indieauth_scopes' ), 11 );
 		add_filter( 'indieauth_response', array( $cls, 'indieauth_response' ), 11 );
 
-		if ( $user ) {
-			return $user;
+		if ( $user_id ) {
+			return $user_id;
 		}
-
-		return $user_id;
+		// Nothing was found return 0 to indicate no privileges given
+		return 0;
 	}
 
 	private static function authorize_error( $code, $msg ) {
@@ -183,7 +184,7 @@ class Micropub_Authorize {
 			'forbidden',
 			$msg,
 			array(
-				'status' => $code
+				'status' => $code,
 			)
 		);
 	}

--- a/includes/class-micropub-authorize.php
+++ b/includes/class-micropub-authorize.php
@@ -38,9 +38,6 @@ class Micropub_Authorize {
 		// The WordPress IndieAuth plugin uses priority 30
 		add_filter( 'determine_current_user', array( $cls, 'determine_current_user' ), 31 );
 
-		// IndieAuth Plugin uses priority 9		
-		add_filter( 'indieauth_scopes', array( $cls, 'indieauth_scopes' ), 11 );
-		add_filter( 'indieauth_response', array( $cls, 'indieauth_response' ), 11 );
 	}
 
 	public static function indieauth_scopes( $scopes ) {
@@ -167,6 +164,10 @@ class Micropub_Authorize {
 
 		// look for a user with the same url as the token's `me` value.
 		$user = static::user_url( $me );
+
+		// IndieAuth Plugin uses priority 9		
+		add_filter( 'indieauth_scopes', array( $cls, 'indieauth_scopes' ), 11 );
+		add_filter( 'indieauth_response', array( $cls, 'indieauth_response' ), 11 );
 
 		if ( $user ) {
 			return $user;

--- a/includes/class-micropub-authorize.php
+++ b/includes/class-micropub-authorize.php
@@ -191,7 +191,7 @@ class Micropub_Authorize {
 
 	/**
 	 * Try to match a user with a URL with or without trailing slash.
-	 *
+	 * TODO: Rename function to something more descriptive
 	 * @param string $me URL to match
 	 *
 	 * @return null|int Return user ID if matched or null

--- a/micropub.php
+++ b/micropub.php
@@ -28,10 +28,19 @@
  * 5. Extract the access_token parameter from the response body.
  */
 
+if ( ! defined( 'MICROPUB_LOCAL_AUTH' ) ) {
+	        define( 'MICROPUB_LOCAL_AUTH', '0' );
+}
+
 register_activation_hook( __FILE__, array( 'Micropub_Admin', 'activate' ) );
 
 // Admin Menu Functions
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-micropub-admin.php';
+
+
+if ( MICROPUB_LOCAL_AUTH || ! class_exists( 'IndieAuth_Plugin' ) ) {
+	require_once plugin_dir_path( __FILE__ ) . 'includes/class-micropub-authorize.php';
+}
 
 // Server Functions
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-micropub-endpoint.php';

--- a/micropub.php
+++ b/micropub.php
@@ -29,7 +29,7 @@
  */
 
 if ( ! defined( 'MICROPUB_LOCAL_AUTH' ) ) {
-	        define( 'MICROPUB_LOCAL_AUTH', '0' );
+	define( 'MICROPUB_LOCAL_AUTH', '0' );
 }
 
 register_activation_hook( __FILE__, array( 'Micropub_Admin', 'activate' ) );

--- a/readme.md
+++ b/readme.md
@@ -134,7 +134,10 @@ If that doesn't work, [try this line](https://github.com/georgestephanis/applica
 
     RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
-If that doesn't work either, you may need to ask your hosting provider to whitelist the `Authorization` header for your account. If they refuse, you can [pass it through Apache with an alternate name](https://github.com/snarfed/wordpress-micropub/issues/56#issuecomment-299569822), but [you'll need to edit this plugin's code to read from that alternate name](https://github.com/snarfed/wordpress-micropub/issues/56#issuecomment-299569822).
+If that doesn't work either, you may need to ask your hosting provider to whitelist the `Authorization` header for your account. If they refuse, you can [pass it through Apache with an alternate name](https://github.com/snarfed/wordpress-micropub/issues/56#issuecomment-299569822). The plugin searches for the header in REDIRECT_HTTP_AUTHORIZATION, as some FastCGI implementations store the header in this location.
+
+If you are getting an `Unauthorized` error despite passing a valid access token then your WordPress installation may not be able to match your user account with the provided URL. The easiest way to 
+resolve is to add the URL you are using as the URL in your user profile. 
 
 
 ## Upgrade Notice 
@@ -181,6 +184,14 @@ into markdown and saved to readme.md.
 
 
 ## Changelog 
+
+
+### 2.0.0 (2018-xx-xx) 
+* Split plugin into files by functionality
+* Change authorization to integrate with WordPress mechanisms for login
+* Reject where the URL cannot be matched with a user account
+* Use `indieauth_scopes` and `indieauth_response` originally added for IndieAuth integration to be used by built in auth as well
+* Improve handling of access tokens in headers to cover additional cases
 
 
 ### 1.4.3 (2018-05-27) 

--- a/readme.txt
+++ b/readme.txt
@@ -135,7 +135,10 @@ If that doesn't work, [try this line](https://github.com/georgestephanis/applica
 
     RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
-If that doesn't work either, you may need to ask your hosting provider to whitelist the `Authorization` header for your account. If they refuse, you can [pass it through Apache with an alternate name](https://github.com/snarfed/wordpress-micropub/issues/56#issuecomment-299569822), but [you'll need to edit this plugin's code to read from that alternate name](https://github.com/snarfed/wordpress-micropub/issues/56#issuecomment-299569822).
+If that doesn't work either, you may need to ask your hosting provider to whitelist the `Authorization` header for your account. If they refuse, you can [pass it through Apache with an alternate name](https://github.com/snarfed/wordpress-micropub/issues/56#issuecomment-299569822). The plugin searches for the header in REDIRECT_HTTP_AUTHORIZATION, as some FastCGI implementations store the header in this location.
+
+If you are getting an `Unauthorized` error despite passing a valid access token then your WordPress installation may not be able to match your user account with the provided URL. The easiest way to 
+resolve is to add the URL you are using as the URL in your user profile. 
 
 == Upgrade Notice ==
 
@@ -178,6 +181,13 @@ To automatically convert the readme.txt file to readme.md, you may, if you have 
 into markdown and saved to readme.md.
 
 == Changelog ==
+
+= 2.0.0 (2018-xx-xx) =
+* Split plugin into files by functionality
+* Change authorization to integrate with WordPress mechanisms for login
+* Reject where the URL cannot be matched with a user account
+* Use `indieauth_scopes` and `indieauth_response` originally added for IndieAuth integration to be used by built in auth as well
+* Improve handling of access tokens in headers to cover additional cases
 
 = 1.4.3 (2018-05-27) =
 * Change scopes to filter


### PR DESCRIPTION
This PR splits authorization into its own file. It also changes the load process for it by making it use the WordPress login functionality of get_current_user_id, which calls wp_get_current_user which calls the determine_current_user filter

As one change, if it cannot determine a user ID, it will not let the post  be made, as it cannot match it up with an existing user. I think this can be addressed by improving user_url, which I intend to update in a future PR to include the improvements made in the similar IndieAuth function...matching the default user if set by the  IndieWeb plugin, checking to see if there is only a single user, or only a single user with author permissions, etc. Also, allowing the author URL(/author/snarfed) as an initial URL.) 

As part of  the changes I'm trying to make, I'm  trying to move the  code to work more within the WordPress core code, and trying to divide this work into pieces. 