### PR TITLE
Move permissions to be checked before all other actions

### DIFF
--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -175,7 +175,8 @@ class Micropub_Endpoint {
 		if ( ! $inscope ) {
 			return new WP_Micropub_Error( 'insufficient_scope', sprintf( 'scope insufficient to %1$s posts', $scope ), 403, static::$scopes );
 		}
-		if ( ! $user_id ) {
+		// Because 0 is a user
+		if ( is_null( $user_id ) ) {
 			return true;
 		}
 		switch ( $scope ) {

--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -87,23 +87,9 @@ class Micropub_Endpoint {
 		);
 	}
 
-
-	public static function get_action( $request ) {
-		$action = $request->get_param( 'action' );
-		return $action ? $action : 'create';
-	}
-
 	public static function load_auth() {
 		static::$micropub_auth_response = apply_filters( 'indieauth_response', static::$micropub_auth_response );
 		static::$scopes                 = apply_filters( 'indieauth_scopes', static::$scopes );
-	}
-
-	public static function get_client_id() {
-		return self::get( static::$micropub_auth_response, 'client_id', false );
-	}
-
-	public static function get_me() {
-		return self::get( static::$micropub_auth_response, 'me', false );
 	}
 
 	public static function check_query_permissions( $request ) {
@@ -120,7 +106,10 @@ class Micropub_Endpoint {
 
 	public static function check_post_permissions( $request ) {
 		self::load_auth();
-		$action     = self::get_action( $request );
+
+		$action = $request->get_param( 'action' );
+		$action = $action ? $action : 'create';
+
 		$permission = self::check_scope( $action, get_current_user_id() );
 		if ( is_micropub_error( $permission ) ) {
 			return $permission->to_wp_error();
@@ -163,17 +152,18 @@ class Micropub_Endpoint {
 	}
 
 	/**
-	 * Check scope
+	 * Check scope.
+	 * If a user id is supplied check the scope against the user permissions otherwise just check scopes
 	 *
 	 * @param string $scope
-	 * @param id $user_id. If supplied will check user permissions
+	 * @param id $user_id. Optional.
 	 *
 	 * @return boolean|WP_Micropub_Error
 	**/
 	protected static function check_scope( $scope, $user_id = null ) {
 		$inscope = in_array( $scope, static::$scopes, true ) || in_array( 'post', static::$scopes, true );
 		if ( ! $inscope ) {
-			return new WP_Micropub_Error( 'insufficient_scope', sprintf( 'scope insufficient to %1$s posts', $scope ), 403, static::$scopes );
+			return new WP_Micropub_Error( 'insufficient_scope', sprintf( 'scope insufficient to %1$s posts', $scope ), 401, static::$scopes );
 		}
 		// Because 0 is a user
 		if ( is_null( $user_id ) ) {
@@ -231,44 +221,54 @@ class Micropub_Endpoint {
 
 		if ( $unknown ) {
 			return new WP_Micropub_Error( 'invalid_request', sprintf( 'Unknown mp-syndicate-to targets: %1$s', implode( ', ', $unknown ) ), 400 );
-
-		} elseif ( ! $url || 'create' === $action ) { // create
-			$args = static::create( $user_id );
-			if ( ! is_micropub_error( $args ) ) {
-				$response->set_status( 201 );
-				$response->header( 'Location', get_permalink( $args['ID'] ) );
-			}
-		} elseif ( 'update' === $action || ! $action ) { // update
-			$args = static::update( static::$input );
-
-		} elseif ( 'delete' === $action ) { // delete
-			$args = get_post( url_to_postid( $url ), ARRAY_A );
-			if ( ! $args ) {
-				return new WP_Micropub_Error( 'invalid_request', sprintf( '%1$s not found', $url ), 400 );
-			}
-			static::check_error( wp_trash_post( $args['ID'] ) );
-
-		} elseif ( 'undelete' === $action ) { // undelete
-			$found = false;
-			// url_to_postid() doesn't support posts in trash, so look for
-			// it ourselves, manually.
-			// here's another, more complicated way that customizes WP_Query:
-			// https://gist.github.com/peterwilsoncc/bb40e52cae7faa0e6efc
-			foreach ( get_posts( array( 'post_status' => 'trash' ) ) as $post ) {
-				if ( get_the_guid( $post ) === $url ) {
-					wp_untrash_post( $post->ID );
-					wp_publish_post( $post->ID );
-					$found = true;
-					$args  = array( 'ID' => $post->ID );
+		}
+		// For all actions other than creation a url is required
+		if ( ! $url && 'create' !== $action ) {
+			return new WP_Micropub_Error( 'invalid_request', sprintf( 'URL is Required for %1$s action', $action ), 400 );
+		}
+		switch ( $action ) {
+			case 'create':
+				$args = static::create( $user_id );
+				if ( ! is_micropub_error( $args ) ) {
+					$response->set_status( 201 );
+					$response->header( 'Location', get_permalink( $args['ID'] ) );
 				}
-			}
-			if ( ! $found ) {
-				return new WP_Micropub_Error( 'invalid_request', sprintf( 'deleted post %1$s not found', $url ), 400 );
-			}
-
-			// unknown action
-		} else {
-			return new WP_Micropub_Error( 'invalid_request', sprintf( 'unknown action %1$s', $action ), 400 );
+				break;
+			case 'update':
+				$args = static::update( static::$input );
+				break;
+			case 'delete':
+				$args = get_post( url_to_postid( $url ), ARRAY_A );
+				if ( ! $args ) {
+					return new WP_Micropub_Error( 'invalid_request', sprintf( '%1$s not found', $url ), 400 );
+				}
+				static::check_error( wp_trash_post( $args['ID'] ) );
+				break;
+			case 'undelete':
+				$found = false;
+				// url_to_postid() doesn't support posts in trash, so look for
+				// it ourselves, manually.
+				// here's another, more complicated way that customizes WP_Query:
+				// https://gist.github.com/peterwilsoncc/bb40e52cae7faa0e6efc
+				foreach ( get_posts(
+					array(
+						'post_status' => 'trash',
+						'fields'      => 'ids',
+					)
+				) as $post_id ) {
+					if ( get_the_guid( $post_id ) === $url ) {
+						wp_untrash_post( $post_id );
+						wp_publish_post( $post_id );
+						$found = true;
+						$args  = array( 'ID' => $post_id );
+					}
+				}
+				if ( ! $found ) {
+					return new WP_Micropub_Error( 'invalid_request', sprintf( 'deleted post %1$s not found', $url ), 400 );
+				}
+				break;
+			default:
+				return new WP_Micropub_Error( 'invalid_request', sprintf( 'unknown action %1$s', $action ), 400 );
 		}
 		if ( is_micropub_error( $args ) ) {
 			return $args;

--- a/tests/test_endpoint.php
+++ b/tests/test_endpoint.php
@@ -42,7 +42,7 @@ class Micropub_Endpoint_Test extends WP_UnitTestCase {
 		'nonce'     => 501884823,
 	);
 
-	// Scope defaulting to legacy params
+	// Scope defaulting to legacy
 	protected static $scopes = array( 'post' );
 
 	protected static $geo = array(
@@ -148,8 +148,11 @@ class Micropub_Endpoint_Test extends WP_UnitTestCase {
 		return $response;
 	}
 
-	public function check_create( $request ) {
-		$response = $this->dispatch( $request, static::$author_id );
+	public function check_create( $request, $user_id = null ) {
+		if ( ! $user_id ) {
+			$user_id = static::$author_id;
+		}
+		$response = $this->dispatch( $request, $user_id );
 		$response = $this->check( $response, 201, null );
 		$posts    = wp_get_recent_posts( null, OBJECT );
 		$this->assertEquals( 1, count( $posts ) );
@@ -198,6 +201,15 @@ class Micropub_Endpoint_Test extends WP_UnitTestCase {
 		// Set Back to Default
 		static::$scopes = array( 'post' );
 	}
+
+	public function test_create_post_subscriber_id() {
+		static::$scopes = array( 'create' );
+		$response       = $this->dispatch( self::create_form_request( static::$post ), static::$subscriber_id );
+		self::check( $response, 403, sprintf( 'user id %1$s cannot create posts', static::$subscriber_id ) );
+		// Set Back to Default
+		static::$scopes = array( 'post' );
+	}
+ 
 
 	public function test_form_to_json_encode() {
 		$output = Micropub_Endpoint::form_to_json( static::$post );
@@ -578,7 +590,7 @@ EOF;
 			'url'    => 'http://example.org/?p=' . $post_id,
 		);
 		$response = $this->dispatch( self::create_form_request( $POST ), static::$author_id );
-		$this->check( $response, 400, 'unknown action' );
+		$this->check( $response, 400, 'Unknown Action' );
 	}
 
 	// https://github.com/snarfed/wordpress-micropub/issues/57#issuecomment-302965336

--- a/tests/test_endpoint.php
+++ b/tests/test_endpoint.php
@@ -468,7 +468,7 @@ EOF;
 			'replace' => array( 'content' => array( 'unused' ) ),
 		);
 		$response = $this->dispatch( self::create_json_request( $input ), static::$subscriber_id );
-		$this->check( $response, 403, sprintf( 'user id %1$s cannot create posts', static::$subscriber_id ) );
+		$this->check( $response, 403, sprintf( 'user id %1$s cannot update posts', static::$subscriber_id ) );
 	}
 
 


### PR DESCRIPTION
This PR just moves permissions to be checked before all other actions and enhances the scope check to check the scope against the user who is authorized to use it.

I'm thinking of adding something to the IndieAuth endpoint to not grant scopes that don't match user permissions in the first place, but IndieAuth.com doesn't do that.

It also moves setting scope and auth response into the permissions check functionality.