### PR TITLE
Notices and Query

### DIFF
--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -425,7 +425,7 @@ class Micropub_Endpoint {
 				);
 			}
 		}
-
+		// Delete was moved to before replace in versions greater than 1.4.3 due to the fact that all items should be removed before replacement
 		// delete
 		$delete = mp_get( $input, 'delete', false );
 		if ( $delete ) {
@@ -476,7 +476,10 @@ class Micropub_Endpoint {
 		// wp_update_post sets it to the current time
 		$args['edit_date'] = true;
 
-		// Generate Post Content
+		/* Filter Post Content
+		 * Post Content is initially generated from content properties in the mp_to_wp function however this function is called
+		 * multiple times for replace and delete
+		*/
 		$post_content = mp_get( $args, 'post_content', '' );
 		$post_content = apply_filters( 'micropub_post_content', $post_content, static::$input );
 		if ( $post_content ) {
@@ -618,10 +621,7 @@ class Micropub_Endpoint {
 			} elseif ( $content ) {
 				$args['post_content'] = htmlspecialchars( $content );
 			}
-		} elseif ( isset( $props['summary'] ) ) {
-			$args['post_content'] = $props['summary'][0];
 		}
-
 		return $args;
 	}
 

--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -426,18 +426,6 @@ class Micropub_Endpoint {
 			}
 		}
 
-		// replace
-		$replace = mp_get( $input, 'replace', false );
-		if ( $replace ) {
-			if ( ! is_array( $replace ) ) {
-				return new WP_Micropub_Error( 'invalid_request', 'replace must be an object', 400 );
-			}
-			foreach ( static::mp_to_wp( array( 'properties' => $replace ) )
-					as $name => $val ) {
-				$args[ $name ] = $val;
-			}
-		}
-
 		// delete
 		$delete = mp_get( $input, 'delete', false );
 		if ( $delete ) {
@@ -469,6 +457,18 @@ class Micropub_Endpoint {
 				}
 			} else {
 				return new WP_Micropub_Error( 'invalid_request', 'delete must be an array or object', 400 );
+			}
+		}
+
+		// replace
+		$replace = mp_get( $input, 'replace', false );
+		if ( $replace ) {
+			if ( ! is_array( $replace ) ) {
+				return new WP_Micropub_Error( 'invalid_request', 'replace must be an object', 400 );
+			}
+			foreach ( static::mp_to_wp( array( 'properties' => $replace ) )
+				as $name => $val ) {
+				$args[ $name ] = $val;
 			}
 		}
 

--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -205,14 +205,12 @@ class Micropub_Endpoint {
 			return $load;
 		}
 
-
 		$action = mp_get( static::$input, 'action', 'create' );
 		if ( ! self::check_scope( $action ) ) {
 			return new WP_Micropub_Error( 'insufficient_scope', sprintf( 'scope insufficient to %1$s posts', $action ), 403 );
 		}
 
 		$url = mp_get( static::$input, 'url' );
-
 
 		// check that we support all requested syndication targets
 		$synd_supported = self::get_syndicate_targets( $user_id );
@@ -612,14 +610,15 @@ class Micropub_Endpoint {
 				}
 			}
 		}
-
-		$content = $props['content'][0];
-		if ( is_array( $content ) ) {
-			$args['post_content'] = $content['html'] ?:
-								htmlspecialchars( $content['value'] );
-		} elseif ( $content ) {
-			$args['post_content'] = htmlspecialchars( $content );
-		} elseif ( $props['summary'] ) {
+		if ( isset( $props['content'] ) ) {
+			$content = $props['content'][0];
+			if ( is_array( $content ) ) {
+				$args['post_content'] = $content['html'] ?:
+							htmlspecialchars( $content['value'] );
+			} elseif ( $content ) {
+				$args['post_content'] = htmlspecialchars( $content );
+			}
+		} elseif ( isset( $props['summary'] ) ) {
 			$args['post_content'] = $props['summary'][0];
 		}
 

--- a/includes/class-micropub-render.php
+++ b/includes/class-micropub-render.php
@@ -75,7 +75,11 @@ class Micropub_Render {
 			$lines[] = static::generate_event( $input );
 		}
 
-		// content
+		// If there is no content use the summary property as content
+		if ( empty( $post_content ) && isset( $props['summary'] ) ) {
+			$post_content = $props['summary'][0];
+		}
+
 		if ( ! empty( $post_content ) ) {
 			$lines[] = '<div class="e-content">';
 			$lines[] = $post_content;

--- a/includes/class-micropub-render.php
+++ b/includes/class-micropub-render.php
@@ -14,7 +14,7 @@ class Micropub_Render {
 	 * and friends.
 	 */
 	public static function generate_post_content( $post_content, $input ) {
-		$props = mp_get( $input, 'replace', $input['properties'] );
+		$props = mp_get( $input, 'properties' );
 		$lines = array();
 
 		$verbs = array(

--- a/includes/class-micropub-render.php
+++ b/includes/class-micropub-render.php
@@ -76,14 +76,9 @@ class Micropub_Render {
 		}
 
 		// content
-		$content = $props['content'][0];
-		if ( $content ) {
+		if ( ! empty( $post_content ) ) {
 			$lines[] = '<div class="e-content">';
-			if ( is_array( $content ) ) {
-				$lines[] = $content['html'] ?: htmlspecialchars( $content['value'] );
-			} else {
-				$lines[] = htmlspecialchars( $content );
-			}
+			$lines[] = $post_content;
 			$lines[] = '</div>';
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -120,7 +120,7 @@ These configuration options can be enabled by adding them to your wp-config.php
 * `define('MICROPUB_TOKEN_ENDPOINT', 'https://tokens.indieauth.com/token')` - Define a custom token endpoint
 * `define('MICROPUB_NAMESPACE', 'micropub/1.0' )` - By default the namespace for micropub is micropub/1.0. This would allow you to change this for your endpoint
 
-These configuration options can be enabled by setting them in the WordPress options table or will appear under General if you install the IndieAuth plugin.
+These configuration options can be enabled by setting them in the WordPress options table.
 * `indieauth_authorization_endpoint` - if set will override MICROPUB_AUTHENTICATION_ENDPOINT for setting a custom endpoint
 * `indieauth_token_endpoint` - if set will override MICROPUB_TOKEN_ENDPOINT for setting a custom endpoint
 * `micropub_default_post_status` - if set, Micropub posts will be set to this status by default( publish, draft, or private ). Can also be set on the settings page.
@@ -144,7 +144,10 @@ resolve is to add the URL you are using as the URL in your user profile.
 
 ## Upgrade Notice 
 
-None yet.
+
+### Version 2.0.0 
+
+This version changes the Micropub endpoint URL as it now uses the REST API. You may have to update any third-parties that have cached this info.
 
 
 ## Screenshots 

--- a/readme.txt
+++ b/readme.txt
@@ -122,7 +122,7 @@ These configuration options can be enabled by adding them to your wp-config.php
 * `define('MICROPUB_TOKEN_ENDPOINT', 'https://tokens.indieauth.com/token')` - Define a custom token endpoint
 * `define('MICROPUB_NAMESPACE', 'micropub/1.0' )` - By default the namespace for micropub is micropub/1.0. This would allow you to change this for your endpoint
 
-These configuration options can be enabled by setting them in the WordPress options table or will appear under General if you install the IndieAuth plugin.
+These configuration options can be enabled by setting them in the WordPress options table.
 * `indieauth_authorization_endpoint` - if set will override MICROPUB_AUTHENTICATION_ENDPOINT for setting a custom endpoint
 * `indieauth_token_endpoint` - if set will override MICROPUB_TOKEN_ENDPOINT for setting a custom endpoint
 * `micropub_default_post_status` - if set, Micropub posts will be set to this status by default( publish, draft, or private ). Can also be set on the settings page.
@@ -144,7 +144,9 @@ resolve is to add the URL you are using as the URL in your user profile.
 
 == Upgrade Notice ==
 
-None yet.
+= Version 2.0.0 =
+
+This version changes the Micropub endpoint URL as it now uses the REST API. You may have to update any third-parties that have cached this info.
 
 == Screenshots ==
 

--- a/tests/test_endpoint.php
+++ b/tests/test_endpoint.php
@@ -348,7 +348,7 @@ class Micropub_Endpoint_Test extends WP_UnitTestCase {
 		$this->assertEquals( '', get_post_meta( $post->ID, 'geo_public', true ) );
 	}
 
-	public function test_update() {
+	public function test_update_replaceadddelete() {
 		$POST    = self::$post;
 		$post_id = $this->check_create( self::create_form_request( $POST ) )->ID;
 		$this->assertEquals( '2016-01-01 12:01:23', get_post( $post_id )->post_date );
@@ -428,6 +428,25 @@ EOF;
 			$this->query_source( $post->ID )
 		);
 	}
+
+
+	public function test_update_delete_prop() {
+		$POST     = array( 'content' => 'my<br>content' );
+		$post_id  = $this->check_create( self::create_form_request( $POST ) )->ID;
+		$input    = array(
+			'action' => 'update',
+			'url'    => 'http://example.org/?p=' . $post_id,
+			'delete'    => array( 'location' ),
+		);
+		$response = $this->dispatch( self::create_json_request( $input ), static::$author_id );
+		$this->check( $response, 200 );
+		// added
+		$post = get_post( $post_id );
+		$meta = get_post_meta( $post->ID );
+		$this->assertNull( $meta['geo_latitude'] );
+		$this->assertNull( $meta['geo_longitude'] );
+	}
+
 
 	public function test_add_property_not_category() {
 		$post_id  = self::insert_post();

--- a/tests/test_media.php
+++ b/tests/test_media.php
@@ -42,7 +42,7 @@ class Micropub_Media_Test extends WP_UnitTestCase {
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
 		$this->assertArrayHasKey( MICROPUB_NAMESPACE . '/media', $routes );
-		$this->assertCount( 1, $routes[ MICROPUB_NAMESPACE . '/media'] );
+		$this->assertCount( 2, $routes[ MICROPUB_NAMESPACE . '/media'] );
 	}
 
 	public function upload_request() {

--- a/tests/test_render.php
+++ b/tests/test_render.php
@@ -25,15 +25,26 @@ class MicropubRenderTest extends WP_UnitTestCase {
 			$post_content );
 	}
 
-	function check_econtent() {
-		$content = '\n<h1>HTML content!</h1><p>coolio.</p>\n';
+	function test_check_wrap_content() {
+		$content = '<h1>HTML content!</h1><p>coolio.</p>';
 		$input = array(
 			'properties' => array(
 				'content' => array( $content )
 			) );
-		$post_content = Micropub_Render::generate_post_content( 'something', $input );
+		$post_content = Micropub_Render::generate_post_content( $content, $input );
 		$this->assertEquals( "<div class=\"e-content\">\n<h1>HTML content!</h1><p>coolio.</p>\n</div>", $post_content );
 	}
+
+	function test_check_no_content_passed() {
+		$content = '<h1>HTML content!</h1><p>coolio.</p>';
+		$input = array(
+			'properties' => array(
+				'content' => array( $content )
+			) );
+		$post_content = Micropub_Render::generate_post_content( '', $input );
+		$this->assertEquals( "", $post_content );
+	}
+
 
 	function create_interaction( $property ) {
 		$input = array(


### PR DESCRIPTION
This fixes the errors noted in #150 removing the remaining PHP notices as well as fixing the error of the media endpoint having no query option. 

The micropub_post_content filter was completely ignoring that $post_content is passed through and replacing it with the content from properties, which defeats the purpose of a filter, so it now passes the content through to be altered.

However, this revealed a problem that replace occurred before delete, and therefore, it was overriding replace and setting things to null, so I swapped the two. In theory, if you are deleting and replacing something in the same transaction, which test_update does, you should delete first anyway.