### PR TITLE
Add nag notice for insecure sites

### DIFF
--- a/micropub.php
+++ b/micropub.php
@@ -68,7 +68,7 @@ function micropub_not_ssl_notice() {
 	}
 	    ?>
     <div class="notice notice-warning">
-        <p>For security reasons you should use Micropub only on an HTTPS domain. You can disable this message be adding define( 'MICROPUB_DISABLE_NAG', '1' ); to your wp-config.php</p>
+        <p>For security reasons you should use Micropub only on an HTTPS domain.</p>
     </div>
     <?php
 }

--- a/micropub.php
+++ b/micropub.php
@@ -36,6 +36,10 @@ if ( ! defined( 'MICROPUB_NAMESPACE' ) ) {
 	define( 'MICROPUB_NAMESPACE', 'micropub/1.0' );
 }
 
+if ( ! defined( 'MICROPUB_DISABLE_NAG' ) ) {
+	define( 'MICROPUB_DISABLE_NAG', '0' );
+}
+
 // Global Functions
 require_once plugin_dir_path( __FILE__ ) . 'includes/functions.php';
 
@@ -57,4 +61,16 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/class-micropub-endpoint.php
 
 // Render Functions
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-micropub-render.php';
+
+function micropub_not_ssl_notice() {
+	if ( is_ssl() || MICROPUB_DISABLE_NAG ) {
+		return;
+	}
+	    ?>
+    <div class="notice notice-warning">
+        <p>For security reasons you should use Micropub only on an HTTPS domain. You can disable this message be adding define( 'MICROPUB_DISABLE_NAG', '1' ); to your wp-config.php</p>
+    </div>
+    <?php
+}
+add_action( 'admin_notices', 'micropub_not_ssl_notice' );
 

--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,7 @@ These configuration options can be enabled by adding them to your wp-config.php
 * `define('MICROPUB_AUTHENTICATION_ENDPOINT', 'https://indieauth.com/auth')` - Define a custom authentication endpoint.
 * `define('MICROPUB_TOKEN_ENDPOINT', 'https://tokens.indieauth.com/token')` - Define a custom token endpoint
 * `define('MICROPUB_NAMESPACE', 'micropub/1.0' )` - By default the namespace for micropub is micropub/1.0. This would allow you to change this for your endpoint
+* `define('MICROPUB_DISABLE_NAG', '1' ) - Disable notices for insecure sites
 
 These configuration options can be enabled by setting them in the WordPress options table.
 * `indieauth_authorization_endpoint` - if set will override MICROPUB_AUTHENTICATION_ENDPOINT for setting a custom endpoint
@@ -204,6 +205,7 @@ into markdown and saved to readme.md.
 * Improve error handling
 * Ensure compliance with Micropub spec
 * Update composer dependencies and include PHPUnit as a development dependency
+* Add nag notice for http domains and the option to diable with a setting
 
 
 ### 1.4.3 (2018-05-27) 

--- a/readme.txt
+++ b/readme.txt
@@ -121,6 +121,7 @@ These configuration options can be enabled by adding them to your wp-config.php
 * `define('MICROPUB_AUTHENTICATION_ENDPOINT', 'https://indieauth.com/auth')` - Define a custom authentication endpoint.
 * `define('MICROPUB_TOKEN_ENDPOINT', 'https://tokens.indieauth.com/token')` - Define a custom token endpoint
 * `define('MICROPUB_NAMESPACE', 'micropub/1.0' )` - By default the namespace for micropub is micropub/1.0. This would allow you to change this for your endpoint
+* `define('MICROPUB_DISABLE_NAG', '1' ) - Disable notices for insecure sites
 
 These configuration options can be enabled by setting them in the WordPress options table.
 * `indieauth_authorization_endpoint` - if set will override MICROPUB_AUTHENTICATION_ENDPOINT for setting a custom endpoint
@@ -199,6 +200,7 @@ into markdown and saved to readme.md.
 * Improve error handling
 * Ensure compliance with Micropub spec
 * Update composer dependencies and include PHPUnit as a development dependency
+* Add nag notice for http domains and the option to diable with a setting
 
 = 1.4.3 (2018-05-27) =
 * Change scopes to filter


### PR DESCRIPTION
If the site is not SSL this will add a notice telling people. For people who aren't concerned there is a constant they can add to disable the notice.

Ideally, no site should be sending tokens insecurely.