### PR TITLE
If there is a token then do not pass control back to WordPress

### DIFF
--- a/includes/class-micropub-authorize.php
+++ b/includes/class-micropub-authorize.php
@@ -150,7 +150,8 @@ class Micropub_Authorize {
 	}
 
 	/**
-	 * Validate the access token at the token endpoint.
+	 * Attaches to the determine_current_user filter and passes back the $user_id if there is no token.
+	 * However if as token is provided it will validate that token or return 0 and set an error.
 	 *
 	 * https://indieauth.spec.indieweb.org/#access-token-verification
 	 */

--- a/includes/class-micropub-authorize.php
+++ b/includes/class-micropub-authorize.php
@@ -47,6 +47,10 @@ class Micropub_Authorize {
 
 	}
 
+	public static function get_error() {
+		return static::$error;
+	}
+
 	public static function return_micropub_error( $result, $server, $request ) {
 		if ( '/micropub/1.0/endpoint' !== $request->get_route() ) {
 			return $result;
@@ -174,12 +178,12 @@ class Micropub_Authorize {
 			return 0;
 		}
 
-		$code           = wp_remote_retrieve_response_code( $resp );
+		$code           = (int) wp_remote_retrieve_response_code( $resp );
 		$body           = wp_remote_retrieve_body( $resp );
 		$params         = json_decode( $body, true );
 		static::$scopes = explode( ' ', $params['scope'] );
 
-		if ( (int) ( $code / 100 ) !== 2 ) {
+		if ( ( $code / 100 ) !== 2 ) {
 			static::$error = new WP_Micropub_Error( 'invalid_request', 'invalid access token', 403 );
 			return 0;
 		} elseif ( empty( static::$scopes ) ) {
@@ -203,6 +207,7 @@ class Micropub_Authorize {
 			return $user_id;
 		}
 		// Nothing was found return 0 to indicate no privileges given
+		static::$error = new WP_Micropub_Error( 'forbidden', 'user not found', 403, $me );
 		return 0;
 	}
 

--- a/includes/class-micropub-authorize.php
+++ b/includes/class-micropub-authorize.php
@@ -152,10 +152,6 @@ class Micropub_Authorize {
 	 */
 	public static function determine_current_user( $user_id ) {
 		$cls = get_called_class();
-		// Do not try to find a user if one has already been found
-		if ( ! empty( $user_id ) ) {
-			return $user_id;
-		}
 
 		// find the access token
 		$auth  = static::get_authorization_header();
@@ -175,7 +171,7 @@ class Micropub_Authorize {
 		);
 		if ( is_wp_error( $resp ) ) {
 			static::$error = $resp;
-			return $user_id;
+			return 0;
 		}
 
 		$code           = wp_remote_retrieve_response_code( $resp );
@@ -185,10 +181,10 @@ class Micropub_Authorize {
 
 		if ( (int) ( $code / 100 ) !== 2 ) {
 			static::$error = new WP_Micropub_Error( 'invalid_request', 'invalid access token', 403 );
-			return $user_id;
+			return 0;
 		} elseif ( empty( static::$scopes ) ) {
 			static::$error = new WP_Micropub_Error( 'insufficient_scope', 'access token is missing scope', 401 );
-			return $user_id;
+			return 0;
 		}
 
 		$me                             = untrailingslashit( $params['me'] );

--- a/tests/test_authorize.php
+++ b/tests/test_authorize.php
@@ -7,6 +7,20 @@ class Micropub_Authorize_Test extends WP_UnitTestCase {
 	protected static $secondauthor_id;
 	protected static $scopes;
 
+
+	protected static $headers = array(
+			'server' => 'nginx/1.9.15',
+			'date' => 'Mon, 16 May 2016 01:21:08 GMT',
+			'content-type' => 'application/json',
+			'authorization' => 'Bearer abcdef',
+	);
+
+	protected static $token = array(
+			"me" => "http://tacos.com",
+  			"client_id" => "https://app.example.com/",
+			"scope" => "create update delete"
+	);
+
 	public static function scopes( $scope ) {
 		return static::$scopes;
 	}
@@ -44,6 +58,70 @@ class Micropub_Authorize_Test extends WP_UnitTestCase {
 		wp_update_user( array( 'ID' => self::$author_id, 'user_url' => home_url() ) );
 		$user_id = Micropub_Authorize::url_to_user( home_url() );
 		$this->assertEquals( self::$author_id, $user_id );
+		wp_update_user( array( 'ID' => self::$author_id, 'user_url' => 'http://tacos.com' ) );
+	}
+
+	public function test_determine_current_user() {
+		$user_id = Micropub_Authorize::determine_current_user( 0 );
+		$this->assertEquals( 0, $user_id );
+		$error = Micropub_Authorize::get_error();
+		$this->assertNotNull( $error );
+		$data = $error->get_data();
+		$this->assertEquals( $error->get_status(), 401 );
+		$this->assertEquals( $data['error'], 'unauthorized' );
+		$this->assertEquals( $data['error_description'], 'missing access token' );
+	}
+
+	public function response( $code, $response ) {
+		$response = array(
+			'code' => $code,
+			'response' => $response,
+		);
+		return $response;
+	}
+
+	public function verify_token() {
+		$response = $this->response( 200, 'OK' );
+		return array(
+			'headers' => static::$headers, 
+			'response' => $response,
+			'body' => wp_json_encode( static::$token )
+		);
+	}
+
+	public function test_determine_current_user_with_token() {
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer testtoken';
+		add_filter( 'pre_http_request', array( $this, 'verify_token' ) );
+		$user_id = Micropub_Authorize::determine_current_user( 0 );
+		$this->assertEquals( static::$author_id, $user_id );
+	}
+
+	public function failed_token() {
+		$response = $this->response( 401, 'Unauthorized' );
+		return array(
+			'headers' => static::$headers, 
+			'response' => $response,
+			'body' => wp_json_encode( 
+				array(
+					'error' => 'invalid_token',
+					'error_description' => 'Invalid access token'
+				)
+			)
+		);
+	}
+
+	public function test_determine_current_user_with_bad_token() {
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer testtoken';
+		add_filter( 'pre_http_request', array( $this, 'failed_token' ) );
+		$user_id = Micropub_Authorize::determine_current_user( 0 );
+		$error = Micropub_Authorize::get_error();
+		$this->assertEquals( 0, $user_id );
+		$this->assertNotNull( $error );
+		$data = $error->get_data();
+		$this->assertEquals( $error->get_status(), 403 );
+		$this->assertEquals( $data['error'], 'invalid_request' );
+		$this->assertEquals( $data['error_description'], 'invalid access token' );
+
 	}
 
 }

--- a/tests/test_authorize.php
+++ b/tests/test_authorize.php
@@ -37,6 +37,7 @@ class Micropub_Authorize_Test extends WP_UnitTestCase {
 	public static function wpTearDownAfterClass() {
 		self::delete_user( self::$author_id );
 		self::delete_user( self::$secondauthor_id );
+		remove_filter( 'indieauth_scopes', array( 'Micropub_Authorize', 'scopes' ) );
 	}
 	public function setUp() {
 		// parent::setUp();
@@ -94,6 +95,7 @@ class Micropub_Authorize_Test extends WP_UnitTestCase {
 		add_filter( 'pre_http_request', array( $this, 'verify_token' ) );
 		$user_id = Micropub_Authorize::determine_current_user( 0 );
 		$this->assertEquals( static::$author_id, $user_id );
+		remove_filter( 'pre_http_request', array( $this, 'verify_token' ) );
 	}
 
 	public function failed_token() {
@@ -121,7 +123,7 @@ class Micropub_Authorize_Test extends WP_UnitTestCase {
 		$this->assertEquals( $error->get_status(), 403 );
 		$this->assertEquals( $data['error'], 'invalid_request' );
 		$this->assertEquals( $data['error_description'], 'invalid access token' );
-
+		remove_filter( 'pre_http_request', array( $this, 'verify_token' ) );
 	}
 
 }

--- a/tests/test_endpoint.php
+++ b/tests/test_endpoint.php
@@ -101,7 +101,7 @@ class Micropub_Endpoint_Test extends WP_UnitTestCase {
 	}
 
 	public function dispatch( $request, $user_id ) {
-		add_filter( 'indieauth_scopes', array( get_called_class(), 'scopes' ) );
+		add_filter( 'indieauth_scopes', array( get_called_class(), 'scopes' ), 12 );
 		wp_set_current_user( $user_id );
 		return rest_get_server()->dispatch( $request );
 	}

--- a/tests/test_media.php
+++ b/tests/test_media.php
@@ -27,7 +27,7 @@ class Micropub_Media_Test extends WP_UnitTestCase {
 	}
 	public static function wpTearDownAfterClass() {
 		self::delete_user( self::$author_id );
-		remove_filter( 'indieauth_scopes', array( get_called_class(), 'scopes' ) );
+		remove_filter( 'indieauth_scopes', array( get_called_class(), 'scopes' ), 12 );
 	}
 	public function setUp() {
 		// parent::setUp();
@@ -74,7 +74,7 @@ class Micropub_Media_Test extends WP_UnitTestCase {
 
 	public function test_upload_file_with_scope() {
 		static::$scopes = array( 'create' );
-		add_filter( 'indieauth_scopes', array( get_called_class(), 'scopes' ) );
+		add_filter( 'indieauth_scopes', array( get_called_class(), 'scopes' ), 12 );
 		wp_set_current_user( self::$author_id );
 		$response = rest_get_server()->dispatch( self::upload_request() );
 		$data     = $response->get_data();
@@ -90,7 +90,7 @@ class Micropub_Media_Test extends WP_UnitTestCase {
 
 	public function test_empty_upload() {
 		static::$scopes = array( 'create' );
-		add_filter( 'indieauth_scopes', array( get_called_class(), 'scopes' ) );
+		add_filter( 'indieauth_scopes', array( get_called_class(), 'scopes' ), 12 );
 		wp_set_current_user( self::$author_id );
 		$request = new WP_REST_Request( 'POST', MICROPUB_NAMESPACE . '/media' );
 		$response = rest_get_server()->dispatch( $request );
@@ -100,7 +100,7 @@ class Micropub_Media_Test extends WP_UnitTestCase {
 
 	public function test_upload_file_without_scope() {
 		static::$scopes = array();
-		add_filter( 'indieauth_scopes', array( get_called_class(), 'scopes' ) );
+		add_filter( 'indieauth_scopes', array( get_called_class(), 'scopes' ), 12 );
 		wp_set_current_user( self::$author_id );
 		$response = rest_get_server()->dispatch( self::upload_request() );
 		$data     = $response->get_data();
@@ -109,7 +109,7 @@ class Micropub_Media_Test extends WP_UnitTestCase {
 
 	public function test_upload_file_with_scope_but_insufficient_permissions() {
 		static::$scopes = array( 'create' );
-		add_filter( 'indieauth_scopes', array( get_called_class(), 'scopes' ) );
+		add_filter( 'indieauth_scopes', array( get_called_class(), 'scopes' ), 12 );
 		wp_set_current_user( self::$subscriber_id );
 		$response = rest_get_server()->dispatch( self::upload_request() );
 		$data     = $response->get_data();


### PR DESCRIPTION
This came up in regard to Omnibear, which is a browser extension Micropub client. Because the browser was logged into the WordPress site, cookie auth was being utilized and the individual was logged in, however, without scope as they didn't come from a token.

This change removes that check. Now, if there is no token, it will try cookie auth, but if there is a bad token, it will fail even if the person is logged in in that browser.