### PR TITLE
Reject cookie authentication

### DIFF
--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -96,9 +96,11 @@ class Micropub_Endpoint {
 		}
 
 		// If there is no auth response this is cookie authentication which should be rejected
+		// https://www.w3.org/TR/micropub/#authentication-and-authorization - Requests must be authenticated by token
 		if ( empty( static::$micropub_auth_response ) ) {
 			return new WP_Error( 'unauthorized', 'Cookie Authentication is not permitted', array( 'status' => 401 ) );
 		}
+		return true;
 	}
 
 	public static function check_query_permissions( $request ) {

--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -90,22 +90,35 @@ class Micropub_Endpoint {
 	public static function load_auth() {
 		static::$micropub_auth_response = apply_filters( 'indieauth_response', static::$micropub_auth_response );
 		static::$scopes                 = apply_filters( 'indieauth_scopes', static::$scopes );
+		// Every user should have this capability which reflects the ability to access your user profile and the admin dashboard
+		if ( ! current_user_can( 'read' ) ) {
+			return new WP_Error( 'forbidden', 'Unauthorized', array( 'status' => 403 ) );
+		}
+
+		// If there is no auth response this is cookie authentication which should be rejected
+		if ( empty( static::$micropub_auth_response ) ) {
+			return new WP_Error( 'unauthorized', 'Cookie Authentication is not permitted', array( 'status' => 401 ) );
+		}
 	}
 
 	public static function check_query_permissions( $request ) {
-		self::load_auth();
+		$auth = self::load_auth();
+		if ( is_wp_error( $auth ) ) {
+			return $auth;
+		}
 		$query = $request->get_param( 'q' );
 		if ( ! $query ) {
 			return new WP_Error( 'invalid_request', 'Missing Query Parameter', array( 'status' => 400 ) );
 		}
-		if ( ! current_user_can( 'read' ) ) {
-			return new WP_Error( 'forbidden', 'Unauthorized', array( 'status' => 403 ) );
-		}
+
 		return true;
 	}
 
 	public static function check_post_permissions( $request ) {
-		self::load_auth();
+		$auth = self::load_auth();
+		if ( is_wp_error( $auth ) ) {
+			return $auth;
+		}
 
 		$action = $request->get_param( 'action' );
 		$action = $action ? $action : 'create';

--- a/micropub.php
+++ b/micropub.php
@@ -66,11 +66,11 @@ function micropub_not_ssl_notice() {
 	if ( is_ssl() || MICROPUB_DISABLE_NAG ) {
 		return;
 	}
-	    ?>
-    <div class="notice notice-warning">
-        <p>For security reasons you should use Micropub only on an HTTPS domain.</p>
-    </div>
-    <?php
+	?>
+	<div class="notice notice-warning">
+		<p>For security reasons you should use Micropub only on an HTTPS domain.</p>
+	</div>
+	<?php
 }
 add_action( 'admin_notices', 'micropub_not_ssl_notice' );
 


### PR DESCRIPTION
This attempts to reject all requests to the endpoint that might come over cookie authentication, to address more of the Omnibear issue(as the browser based extension is getting confused when someone is logged into the site in the same browser). I tried to simplify this a bit by failing if the auth response is empty.