### PR TITLE
Change config to filter

### DIFF
--- a/micropub.php
+++ b/micropub.php
@@ -28,10 +28,6 @@
  * 5. Extract the access_token parameter from the response body.
  */
 
-if ( ! defined( 'MICROPUB_LOCAL_AUTH' ) ) {
-	define( 'MICROPUB_LOCAL_AUTH', '0' );
-}
-
 if ( ! defined( 'MICROPUB_NAMESPACE' ) ) {
 	define( 'MICROPUB_NAMESPACE', 'micropub/1.0' );
 }
@@ -46,7 +42,7 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/functions.php';
 // Admin Menu Functions
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-micropub-admin.php';
 
-if ( MICROPUB_LOCAL_AUTH || ! class_exists( 'IndieAuth_Plugin' ) ) {
+if ( ! apply_filters( 'disable_micropub_auth', class_exists( 'IndieAuth_Plugin' ) ) ) {
 	require_once plugin_dir_path( __FILE__ ) . 'includes/class-micropub-authorize.php';
 }
 

--- a/micropub.php
+++ b/micropub.php
@@ -51,8 +51,8 @@ function load_micropub_auth() {
 	if ( class_exists( 'IndieAuth_Plugin' ) ) {
 		return;
 	}
-	// Set this filter to false to disable built in authorization
-	if ( apply_filters( 'enable_micropub_auth', (0 === MICROPUB_LOCAL_AUTH ) ) ) {
+	// If this configuration option is set to 0 then load this file
+	if ( 0 === MICROPUB_LOCAL_AUTH ) {
 		require_once plugin_dir_path( __FILE__ ) . 'includes/class-micropub-authorize.php';
 	
 	}

--- a/micropub.php
+++ b/micropub.php
@@ -33,7 +33,11 @@ if ( ! defined( 'MICROPUB_NAMESPACE' ) ) {
 }
 
 if ( ! defined( 'MICROPUB_DISABLE_NAG' ) ) {
-	define( 'MICROPUB_DISABLE_NAG', '0' );
+	define( 'MICROPUB_DISABLE_NAG', 0 );
+}
+
+if ( ! defined( 'MICROPUB_LOCAL_AUTH' ) ) {
+	define( 'MICROPUB_LOCAL_AUTH', 0 );
 }
 
 // Global Functions
@@ -42,7 +46,12 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/functions.php';
 // Admin Menu Functions
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-micropub-admin.php';
 
-if ( ! apply_filters( 'disable_micropub_auth', class_exists( 'IndieAuth_Plugin' ) ) ) {
+function disable_micropub_auth() {
+	$load = ( class_exists( 'IndieAuth_Plugin' ) || MICROPUB_LOCAL_AUTH );
+	return ! apply_filters( 'disable_micropub_auth', $load );
+}
+
+if ( disable_micropub_auth() ) {
 	require_once plugin_dir_path( __FILE__ ) . 'includes/class-micropub-authorize.php';
 }
 

--- a/micropub.php
+++ b/micropub.php
@@ -46,14 +46,20 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/functions.php';
 // Admin Menu Functions
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-micropub-admin.php';
 
-function disable_micropub_auth() {
-	$load = ( class_exists( 'IndieAuth_Plugin' ) || MICROPUB_LOCAL_AUTH );
-	return ! apply_filters( 'disable_micropub_auth', $load );
+function load_micropub_auth() {
+	// Always disable local auth when the IndieAuth Plugin is installed
+	if ( class_exists( 'IndieAuth_Plugin' ) ) {
+		return;
+	}
+	// Set this filter to false to disable built in authorization
+	if ( apply_filters( 'enable_micropub_auth', (0 === MICROPUB_LOCAL_AUTH ) ) ) {
+		require_once plugin_dir_path( __FILE__ ) . 'includes/class-micropub-authorize.php';
+	
+	}
 }
 
-if ( disable_micropub_auth() ) {
-	require_once plugin_dir_path( __FILE__ ) . 'includes/class-micropub-authorize.php';
-}
+// Load auth at the plugins loaded stage in order to ensure it occurs after the IndieAuth plugin is loaded
+add_action( 'plugins_loaded', 'load_micropub_auth', 20 );
 
 // Error Handling Class
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-micropub-error.php';

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ Supports the following [scope](https://indieweb.org/scope) parameters requested 
 
 
 ### Filters and hooks 
-Adds seven filters:
+Adds six filters:
 
 `before_micropub( $input )`
 
@@ -48,11 +48,6 @@ Called to generate the list of `syndicate-to` targets to return in response to a
 `micropub_query( $resp, $input )`
 
 $resp defaults to null. If the return value is non-null, it should be an associative array that is encoded as JSON and will be returned in place of the normal micropub response.
-
-`enable_micropub_auth( $boolean )`
-
-If this filter returns true the authentication functions built into the plugin are enabled. By default, this is disabled if the IndieAuth Plugin is installed. By default it will return
-true which loads the built-in IndieAuth client.
 
 `indieauth_scopes( $scopes )`
 
@@ -109,9 +104,13 @@ WordPress has a [whitelist of file extensions that it allows in uploads](https:/
 
 For reasons of security it is recommended that you only use this plugin on sites that implement HTTPS.
 
-Supports the full OAuth2/IndieAuth authentication and authorization flow. Defaults to IndieAuth.com. Custom auth and token endpoints can be used by overriding the `MICROPUB_AUTHENTICATION_ENDPOINT` and `MICROPUB_TOKEN_ENDPOINT` endpoints or by setting the options `indieauth_authorization_endpoint` and `indieauth_token_endpoint`.
+Supports the full OAuth2/IndieAuth authentication and authorization flow. Defaults to IndieAuth.com. Custom auth and token endpoints can be used by overriding the `MICROPUB_AUTHENTICATION_ENDPOINT`
+and `MICROPUB_TOKEN_ENDPOINT` endpoints or by setting the options `indieauth_authorization_endpoint` and `indieauth_token_endpoint`.
 
 If you want to use your own site as an IndieAuth endpoint, you can activate the IndieAuth plugin which is recommended but not required. You can disable the authentication in favor of an alternative plugin.
+This can be done by removing the loading of the auth flow or setting MICROPUB_LOCAL_AUTH to 1.
+
+`remove_action( 'plugins_loaded', 'load_micropub_auth', 20 );` 
 
 If the token's `me` value matches a WordPress user's or author post URL, that user will be used. If there is only one site author that will be matched otherwise.
 
@@ -217,7 +216,7 @@ into markdown and saved to readme.md.
 * Ensure compliance with Micropub spec
 * Update composer dependencies and include PHPUnit as a development dependency
 * Add nag notice for http domains and the option to diable with a setting
-* `MICROPUB_LOCAL_AUTH` is now deprecated in favor of a filter and may be removed in a future version.
+* Load auth later in init sequence to avoid conflict
 
 
 ### 1.4.3 (2018-05-27) 

--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,8 @@ $resp defaults to null. If the return value is non-null, it should be an associa
 
 `disable_micropub_auth( $boolean )`
 
-If this filter returns true the authentication functions built into the plugin are disabled. By default, this is disabled if the IndieAuth Plugin is installed. 
+If this filter returns true the authentication functions built into the plugin are disabled. By default, this is disabled if the IndieAuth Plugin is installed. By default it will return
+false which loads the built-in IndieAuth client.
 
 `indieauth_scopes( $scopes )`
 
@@ -128,7 +129,8 @@ These configuration options can be enabled by adding them to your wp-config.php
 * `define('MICROPUB_AUTHENTICATION_ENDPOINT', 'https://indieauth.com/auth')` - Define a custom authentication endpoint.
 * `define('MICROPUB_TOKEN_ENDPOINT', 'https://tokens.indieauth.com/token')` - Define a custom token endpoint
 * `define('MICROPUB_NAMESPACE', 'micropub/1.0' )` - By default the namespace for micropub is micropub/1.0. This would allow you to change this for your endpoint
-* `define('MICROPUB_DISABLE_NAG', '1' ) - Disable notices for insecure sites
+* `define('MICROPUB_DISABLE_NAG', 1 ) - Disable notices for insecure sites
+* `define('MICROPUB_LOCAL_AUTH', 1 ) - Disable built in AUTH in favor of your own plugin. Recommend plugin developers use the filter `disable_micropub_auth` for this.
 
 These configuration options can be enabled by setting them in the WordPress options table.
 * `indieauth_authorization_endpoint` - if set will override MICROPUB_AUTHENTICATION_ENDPOINT for setting a custom endpoint
@@ -215,7 +217,7 @@ into markdown and saved to readme.md.
 * Ensure compliance with Micropub spec
 * Update composer dependencies and include PHPUnit as a development dependency
 * Add nag notice for http domains and the option to diable with a setting
-* `MICROPUB_LOCAL_AUTH` is now deprecated in favor of a filter
+* `MICROPUB_LOCAL_AUTH` is now deprecated in favor of a filter and may be removed in a future version.
 
 
 ### 1.4.3 (2018-05-27) 

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ A [Micropub](http://micropub.net/) server plugin. Available in the WordPress plu
 
 > Micropub is an open API standard that is used to create posts on one's own domain using third-party clients. Web apps and native apps (e.g. iPhone, Android) can use Micropub to post short notes, photos, events or other posts to your own site, similar to a Twitter client posting to Twitter.com.
 
-Once you've installed and activated the plugin, try using [Quill](http://quill.p3k.io/) to create a new post on your site. It walks you through the steps and helps you troubleshoot if you run into any problems. After that, try other clients like [OwnYourGram](http://ownyourgram.com/), [OwnYourCheckin](https://ownyourcheckin.wirres.net/), [MobilePub](http://indiewebcamp.com/MobilePub), and [Teacup](https://teacup.p3k.io/).
+Once you've installed and activated the plugin, try using [Quill](http://quill.p3k.io/) to create a new post on your site. It walks you through the steps and helps you troubleshoot if you run into any problems. A list of known Micropub clients are available [here](https://indieweb.org/Micropub/Clients)
 
 Supports the [full W3C Micropub CR spec](https://www.w3.org/TR/micropub/) as of version 2.0.0.
 
@@ -32,7 +32,7 @@ Supports the following [scope](https://indieweb.org/scope) parameters requested 
 
 
 ### Filters and hooks 
-Adds four filters:
+Adds seven filters:
 
 `before_micropub( $input )`
 
@@ -44,11 +44,22 @@ Called during the handling of a Micropub request. The content generation functio
 
 `micropub_syndicate-to( $synd_urls, $user_id )`
 
-Called to generate the list of `syndicate-to` targets to return in response to a query. Returns `$synd_urls`, an array, possibly modified.
-
+Called to generate the list of `syndicate-to` targets to return in response to a query. Returns `$synd_urls`, an array, possibly modified. This filter is empty by default
 `micropub_query( $resp, $input )`
 
 $resp defaults to null. If the return value is non-null, it should be an associative array that is encoded as JSON and will be returned in place of the normal micropub response.
+
+`disable_micropub_auth( $boolean )`
+
+If this filter returns true the authentication functions built into the plugin are disabled. By default, this is disabled if the IndieAuth Plugin is installed. 
+
+`indieauth_scopes( $scopes )`
+
+This returns scopes from a plugin implementing IndieAuth or from the internal IndieAuth code. This filter is empty by default.
+
+`indieauth_response( $response )`
+
+This returns the token auth response from a plugin implementing IndieAuth or from the internal IndieAuth code. This filter is empty by default.
 
 ...and two hooks:
 
@@ -57,6 +68,7 @@ $resp defaults to null. If the return value is non-null, it should be an associa
 Called after handling a Micropub request. Not called if the request fails (ie doesn't return HTTP 2xx).
 
 `micropub_syndication( $ID, $syndicate_to )`
+
 
 Called only if there are syndication targets $syndicate_to for post $ID. $syndicate_to will be an array of UIDs that are verified as one or more of the UIDs added using the `micropub_syndicate-to` filter.
 
@@ -94,15 +106,13 @@ WordPress has a [whitelist of file extensions that it allows in uploads](https:/
 
 ## Authentication and authorization 
 
-Supports the full OAuth2/IndieAuth authentication and authorization flow. Defaults to IndieAuth. Custom auth and token endpoints can be used by overriding the `MICROPUB_AUTHENTICATION_ENDPOINT` and `MICROPUB_TOKEN_ENDPOINT` endpoints or by setting the options `indieauth_authorization_endpoint` and `indieauth_token_endpoint`.
+For reasons of security it is recommended that you only use this plugin on sites that implement HTTPS.
+
+Supports the full OAuth2/IndieAuth authentication and authorization flow. Defaults to IndieAuth.com. Custom auth and token endpoints can be used by overriding the `MICROPUB_AUTHENTICATION_ENDPOINT` and `MICROPUB_TOKEN_ENDPOINT` endpoints or by setting the options `indieauth_authorization_endpoint` and `indieauth_token_endpoint`.
+
+If you want to use your own site as an IndieAuth endpoint, you can activate the IndieAuth plugin which is recommended but not required. You can disable the authentication in favor of an alternative plugin.
 
 If the token's `me` value matches a WordPress user's or author post URL, that user will be used. If there is only one site author that will be matched otherwise.
-
-Alternatively, you can set `MICROPUB_LOCAL_AUTH` to 1 to disable the plugin's authorization function, for example if you want authorization to be done by WordPress or another plugin. It will also 
-be disabled if the IndieAuth plugin is installed.
-
-Finally, for ease of development, if the WordPress site is running on `localhost`, it logs a warning if the access token is missing or invalid and still allows the request.
-
 
 
 ## Installation 
@@ -115,7 +125,6 @@ Install from the WordPress plugin directory. No setup needed.
 
 These configuration options can be enabled by adding them to your wp-config.php
 
-* `define('MICROPUB_LOCAL_AUTH', '1')` - Disable this plugins built-in authentication.
 * `define('MICROPUB_AUTHENTICATION_ENDPOINT', 'https://indieauth.com/auth')` - Define a custom authentication endpoint.
 * `define('MICROPUB_TOKEN_ENDPOINT', 'https://tokens.indieauth.com/token')` - Define a custom token endpoint
 * `define('MICROPUB_NAMESPACE', 'micropub/1.0' )` - By default the namespace for micropub is micropub/1.0. This would allow you to change this for your endpoint
@@ -206,6 +215,7 @@ into markdown and saved to readme.md.
 * Ensure compliance with Micropub spec
 * Update composer dependencies and include PHPUnit as a development dependency
 * Add nag notice for http domains and the option to diable with a setting
+* `MICROPUB_LOCAL_AUTH` is now deprecated in favor of a filter
 
 
 ### 1.4.3 (2018-05-27) 

--- a/readme.md
+++ b/readme.md
@@ -49,10 +49,10 @@ Called to generate the list of `syndicate-to` targets to return in response to a
 
 $resp defaults to null. If the return value is non-null, it should be an associative array that is encoded as JSON and will be returned in place of the normal micropub response.
 
-`disable_micropub_auth( $boolean )`
+`enable_micropub_auth( $boolean )`
 
-If this filter returns true the authentication functions built into the plugin are disabled. By default, this is disabled if the IndieAuth Plugin is installed. By default it will return
-false which loads the built-in IndieAuth client.
+If this filter returns true the authentication functions built into the plugin are enabled. By default, this is disabled if the IndieAuth Plugin is installed. By default it will return
+true which loads the built-in IndieAuth client.
 
 `indieauth_scopes( $scopes )`
 

--- a/readme.txt
+++ b/readme.txt
@@ -17,7 +17,7 @@ A [Micropub](http://micropub.net/) server plugin. Available in the WordPress plu
 
 > Micropub is an open API standard that is used to create posts on one's own domain using third-party clients. Web apps and native apps (e.g. iPhone, Android) can use Micropub to post short notes, photos, events or other posts to your own site, similar to a Twitter client posting to Twitter.com.
 
-Once you've installed and activated the plugin, try using [Quill](http://quill.p3k.io/) to create a new post on your site. It walks you through the steps and helps you troubleshoot if you run into any problems. After that, try other clients like [OwnYourGram](http://ownyourgram.com/), [OwnYourCheckin](https://ownyourcheckin.wirres.net/), [MobilePub](http://indiewebcamp.com/MobilePub), and [Teacup](https://teacup.p3k.io/).
+Once you've installed and activated the plugin, try using [Quill](http://quill.p3k.io/) to create a new post on your site. It walks you through the steps and helps you troubleshoot if you run into any problems. A list of known Micropub clients are available [here](https://indieweb.org/Micropub/Clients)
 
 Supports the [full W3C Micropub CR spec](https://www.w3.org/TR/micropub/) as of version 2.0.0.
 
@@ -38,7 +38,7 @@ Supports the following [scope](https://indieweb.org/scope) parameters requested 
 == WordPress details ==
 
 = Filters and hooks =
-Adds four filters:
+Adds seven filters:
 
 `before_micropub( $input )`
 
@@ -50,11 +50,22 @@ Called during the handling of a Micropub request. The content generation functio
 
 `micropub_syndicate-to( $synd_urls, $user_id )`
 
-Called to generate the list of `syndicate-to` targets to return in response to a query. Returns `$synd_urls`, an array, possibly modified.
-
+Called to generate the list of `syndicate-to` targets to return in response to a query. Returns `$synd_urls`, an array, possibly modified. This filter is empty by default
 `micropub_query( $resp, $input )`
 
 $resp defaults to null. If the return value is non-null, it should be an associative array that is encoded as JSON and will be returned in place of the normal micropub response.
+
+`disable_micropub_auth( $boolean )`
+
+If this filter returns true the authentication functions built into the plugin are disabled. By default, this is disabled if the IndieAuth Plugin is installed. 
+
+`indieauth_scopes( $scopes )`
+
+This returns scopes from a plugin implementing IndieAuth or from the internal IndieAuth code. This filter is empty by default.
+
+`indieauth_response( $response )`
+
+This returns the token auth response from a plugin implementing IndieAuth or from the internal IndieAuth code. This filter is empty by default.
 
 ...and two hooks:
 
@@ -63,6 +74,7 @@ $resp defaults to null. If the return value is non-null, it should be an associa
 Called after handling a Micropub request. Not called if the request fails (ie doesn't return HTTP 2xx).
 
 `micropub_syndication( $ID, $syndicate_to )`
+
 
 Called only if there are syndication targets $syndicate_to for post $ID. $syndicate_to will be an array of UIDs that are verified as one or more of the UIDs added using the `micropub_syndicate-to` filter.
 
@@ -98,15 +110,13 @@ WordPress has a [whitelist of file extensions that it allows in uploads](https:/
 
 == Authentication and authorization ==
 
-Supports the full OAuth2/IndieAuth authentication and authorization flow. Defaults to IndieAuth. Custom auth and token endpoints can be used by overriding the `MICROPUB_AUTHENTICATION_ENDPOINT` and `MICROPUB_TOKEN_ENDPOINT` endpoints or by setting the options `indieauth_authorization_endpoint` and `indieauth_token_endpoint`.
+For reasons of security it is recommended that you only use this plugin on sites that implement HTTPS.
+
+Supports the full OAuth2/IndieAuth authentication and authorization flow. Defaults to IndieAuth.com. Custom auth and token endpoints can be used by overriding the `MICROPUB_AUTHENTICATION_ENDPOINT` and `MICROPUB_TOKEN_ENDPOINT` endpoints or by setting the options `indieauth_authorization_endpoint` and `indieauth_token_endpoint`.
+
+If you want to use your own site as an IndieAuth endpoint, you can activate the IndieAuth plugin which is recommended but not required. You can disable the authentication in favor of an alternative plugin.
 
 If the token's `me` value matches a WordPress user's or author post URL, that user will be used. If there is only one site author that will be matched otherwise.
-
-Alternatively, you can set `MICROPUB_LOCAL_AUTH` to 1 to disable the plugin's authorization function, for example if you want authorization to be done by WordPress or another plugin. It will also 
-be disabled if the IndieAuth plugin is installed.
-
-Finally, for ease of development, if the WordPress site is running on `localhost`, it logs a warning if the access token is missing or invalid and still allows the request.
-
 
 == Installation ==
 
@@ -117,7 +127,6 @@ Install from the WordPress plugin directory. No setup needed.
 
 These configuration options can be enabled by adding them to your wp-config.php
 
-* `define('MICROPUB_LOCAL_AUTH', '1')` - Disable this plugins built-in authentication.
 * `define('MICROPUB_AUTHENTICATION_ENDPOINT', 'https://indieauth.com/auth')` - Define a custom authentication endpoint.
 * `define('MICROPUB_TOKEN_ENDPOINT', 'https://tokens.indieauth.com/token')` - Define a custom token endpoint
 * `define('MICROPUB_NAMESPACE', 'micropub/1.0' )` - By default the namespace for micropub is micropub/1.0. This would allow you to change this for your endpoint
@@ -201,6 +210,7 @@ into markdown and saved to readme.md.
 * Ensure compliance with Micropub spec
 * Update composer dependencies and include PHPUnit as a development dependency
 * Add nag notice for http domains and the option to diable with a setting
+* `MICROPUB_LOCAL_AUTH` is now deprecated in favor of a filter
 
 = 1.4.3 (2018-05-27) =
 * Change scopes to filter

--- a/readme.txt
+++ b/readme.txt
@@ -38,7 +38,7 @@ Supports the following [scope](https://indieweb.org/scope) parameters requested 
 == WordPress details ==
 
 = Filters and hooks =
-Adds seven filters:
+Adds six filters:
 
 `before_micropub( $input )`
 
@@ -54,11 +54,6 @@ Called to generate the list of `syndicate-to` targets to return in response to a
 `micropub_query( $resp, $input )`
 
 $resp defaults to null. If the return value is non-null, it should be an associative array that is encoded as JSON and will be returned in place of the normal micropub response.
-
-`enable_micropub_auth( $boolean )`
-
-If this filter returns true the authentication functions built into the plugin are enabled. By default, this is disabled if the IndieAuth Plugin is installed. By default it will return
-true which loads the built-in IndieAuth client.
 
 `indieauth_scopes( $scopes )`
 
@@ -113,9 +108,13 @@ WordPress has a [whitelist of file extensions that it allows in uploads](https:/
 
 For reasons of security it is recommended that you only use this plugin on sites that implement HTTPS.
 
-Supports the full OAuth2/IndieAuth authentication and authorization flow. Defaults to IndieAuth.com. Custom auth and token endpoints can be used by overriding the `MICROPUB_AUTHENTICATION_ENDPOINT` and `MICROPUB_TOKEN_ENDPOINT` endpoints or by setting the options `indieauth_authorization_endpoint` and `indieauth_token_endpoint`.
+Supports the full OAuth2/IndieAuth authentication and authorization flow. Defaults to IndieAuth.com. Custom auth and token endpoints can be used by overriding the `MICROPUB_AUTHENTICATION_ENDPOINT`
+and `MICROPUB_TOKEN_ENDPOINT` endpoints or by setting the options `indieauth_authorization_endpoint` and `indieauth_token_endpoint`.
 
 If you want to use your own site as an IndieAuth endpoint, you can activate the IndieAuth plugin which is recommended but not required. You can disable the authentication in favor of an alternative plugin.
+This can be done by removing the loading of the auth flow or setting MICROPUB_LOCAL_AUTH to 1.
+
+`remove_action( 'plugins_loaded', 'load_micropub_auth', 20 );` 
 
 If the token's `me` value matches a WordPress user's or author post URL, that user will be used. If there is only one site author that will be matched otherwise.
 
@@ -212,7 +211,7 @@ into markdown and saved to readme.md.
 * Ensure compliance with Micropub spec
 * Update composer dependencies and include PHPUnit as a development dependency
 * Add nag notice for http domains and the option to diable with a setting
-* `MICROPUB_LOCAL_AUTH` is now deprecated in favor of a filter and may be removed in a future version.
+* Load auth later in init sequence to avoid conflict
 
 = 1.4.3 (2018-05-27) =
 * Change scopes to filter

--- a/readme.txt
+++ b/readme.txt
@@ -55,10 +55,10 @@ Called to generate the list of `syndicate-to` targets to return in response to a
 
 $resp defaults to null. If the return value is non-null, it should be an associative array that is encoded as JSON and will be returned in place of the normal micropub response.
 
-`disable_micropub_auth( $boolean )`
+`enable_micropub_auth( $boolean )`
 
-If this filter returns true the authentication functions built into the plugin are disabled. By default, this is disabled if the IndieAuth Plugin is installed. By default it will return
-false which loads the built-in IndieAuth client.
+If this filter returns true the authentication functions built into the plugin are enabled. By default, this is disabled if the IndieAuth Plugin is installed. By default it will return
+true which loads the built-in IndieAuth client.
 
 `indieauth_scopes( $scopes )`
 

--- a/readme.txt
+++ b/readme.txt
@@ -57,7 +57,8 @@ $resp defaults to null. If the return value is non-null, it should be an associa
 
 `disable_micropub_auth( $boolean )`
 
-If this filter returns true the authentication functions built into the plugin are disabled. By default, this is disabled if the IndieAuth Plugin is installed. 
+If this filter returns true the authentication functions built into the plugin are disabled. By default, this is disabled if the IndieAuth Plugin is installed. By default it will return
+false which loads the built-in IndieAuth client.
 
 `indieauth_scopes( $scopes )`
 
@@ -130,7 +131,8 @@ These configuration options can be enabled by adding them to your wp-config.php
 * `define('MICROPUB_AUTHENTICATION_ENDPOINT', 'https://indieauth.com/auth')` - Define a custom authentication endpoint.
 * `define('MICROPUB_TOKEN_ENDPOINT', 'https://tokens.indieauth.com/token')` - Define a custom token endpoint
 * `define('MICROPUB_NAMESPACE', 'micropub/1.0' )` - By default the namespace for micropub is micropub/1.0. This would allow you to change this for your endpoint
-* `define('MICROPUB_DISABLE_NAG', '1' ) - Disable notices for insecure sites
+* `define('MICROPUB_DISABLE_NAG', 1 ) - Disable notices for insecure sites
+* `define('MICROPUB_LOCAL_AUTH', 1 ) - Disable built in AUTH in favor of your own plugin. Recommend plugin developers use the filter `disable_micropub_auth` for this.
 
 These configuration options can be enabled by setting them in the WordPress options table.
 * `indieauth_authorization_endpoint` - if set will override MICROPUB_AUTHENTICATION_ENDPOINT for setting a custom endpoint
@@ -210,7 +212,7 @@ into markdown and saved to readme.md.
 * Ensure compliance with Micropub spec
 * Update composer dependencies and include PHPUnit as a development dependency
 * Add nag notice for http domains and the option to diable with a setting
-* `MICROPUB_LOCAL_AUTH` is now deprecated in favor of a filter
+* `MICROPUB_LOCAL_AUTH` is now deprecated in favor of a filter and may be removed in a future version.
 
 = 1.4.3 (2018-05-27) =
 * Change scopes to filter

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,6 @@
 
 error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_WARNING);
 
-define( 'MICROPUB_LOCAL_AUTH', true );
 define( 'MICROPUB_NAMESPACE', '/micropub/1.0' );
 define( 'WP_DEBUG', false );
 define( 'DIR_TESTDATA', dirname( __FILE__ ) . '/data' );

--- a/tests/test_endpoint.php
+++ b/tests/test_endpoint.php
@@ -115,7 +115,7 @@ class Micropub_Endpoint_Test extends WP_UnitTestCase {
 		add_filter( 'indieauth_response', array( get_called_class(), 'empty_auth_response' ), 99 );
 		$auth = Micropub_Endpoint::load_auth();
 		$this->assertEquals( 'unauthorized', $auth->get_error_code() );
-		remove_filter( 'indieauth_response', array( get_called_class(), 'auth_response' ), 99 );
+		remove_filter( 'indieauth_response', array( get_called_class(), 'empty_auth_response' ), 99 );
 	}
 
 	public function test_auth_response() {


### PR DESCRIPTION
Oddly enough, there were issues @miklb had issues with the plugin because it was trying to load both the built-in auth and the IndieAuth. So I decided that a more dynamic way of doing this might make more sense, and retiring the configuration variable.

Since the Micropub spec now says that auth must be in the form of OAuth2 or the IndieAuth variant, it shouldn't support anything called MICROPUB_LOCAL_AUTH. So, the new version disables the auth in favor of it being handled externally. I also added to the documentation.