### PR TITLE
Attach media if already in library

### DIFF
--- a/includes/class-micropub-media.php
+++ b/includes/class-micropub-media.php
@@ -231,6 +231,13 @@ class Micropub_Media {
 		// Check to see if URL is already in the media library
 		$id = attachment_url_to_postid( $url );
 		if ( $id ) {
+			// Attach media to post
+			wp_update_post(
+				array(
+					'post_ID' => $id,
+					'post_parent' => $post_id
+				)
+			);
 			return $id;
 		}
 


### PR DESCRIPTION
This is to address #165 . With the new media endpoint, new attachments are uploaded before the post is created and therefore they ached to posts. This attaches them at the time they are used.