### PR TITLE
Fixes

### DIFF
--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -701,6 +701,12 @@ class Micropub_Endpoint {
 					}
 					$att_urls[] = wp_get_attachment_url( $id );
 				}
+				// Add to the input so will be visible to the after_micropub action
+				if ( ! isset( $input[ $field ] ) ) {
+					$input[ $field ] = $att_urls;
+				} else {
+					$input[ $field ] = array_merge( $input[ $field ], $att_urls );
+				}
 				add_post_meta( $post_id, 'mf2_' . $field, $att_urls, true );
 			}
 		}

--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -329,6 +329,7 @@ class Micropub_Endpoint {
 					$resp = array( 'syndicate-to' => static::get_syndicate_targets( $user_id ) );
 					break;
 				case 'category':
+					// https://github.com/indieweb/micropub-extensions/issues/5
 					$resp = array_merge(
 						get_tags( array( 'fields' => 'names' ) ),
 						get_terms(
@@ -338,6 +339,18 @@ class Micropub_Endpoint {
 							)
 						)
 					);
+					if ( array_key_exists( 'search', static::$input ) ) {
+						$search = static::$input['search'];
+						$resp   = array_values(
+							array_filter(
+								$resp,
+								function( $value ) use ( $search ) {
+									return ( false !== stripos( $value, $search ) );
+								}
+							)
+						);
+					}
+
 					$resp = array( 'categories' => $resp );
 					break;
 				case 'source':

--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -338,6 +338,7 @@ class Micropub_Endpoint {
 							)
 						)
 					);
+					$resp = array( 'categories' => $resp );
 					break;
 				case 'source':
 					$post_id = url_to_postid( static::$input['url'] );

--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -315,70 +315,78 @@ class Micropub_Endpoint {
 		$user_id = get_current_user_id();
 		static::load_input( $request );
 
-		$resp = apply_filters( 'micropub_query', null, static::$input );
-		if ( ! $resp ) {
-			switch ( static::$input['q'] ) {
-				case 'config':
-					$resp = array(
-						'syndicate-to'   => static::get_syndicate_targets( $user_id ),
-						'media-endpoint' => rest_url( MICROPUB_NAMESPACE . '/media' ),
-					);
-					break;
-				case 'syndicate-to':
-					// return syndication targets with filter
-					$resp = array( 'syndicate-to' => static::get_syndicate_targets( $user_id ) );
-					break;
-				case 'category':
-					// https://github.com/indieweb/micropub-extensions/issues/5
-					$resp = array_merge(
-						get_tags( array( 'fields' => 'names' ) ),
-						get_terms(
-							array(
-								'taxonomy' => 'category',
-								'fields'   => 'names',
-							)
+		switch ( static::$input['q'] ) {
+			case 'config':
+				$resp = array(
+					'syndicate-to'   => static::get_syndicate_targets( $user_id ),
+					'media-endpoint' => rest_url( MICROPUB_NAMESPACE . '/media' ),
+					'mp'             => array(
+						'slug',
+						'syndicate-to',
+					), // List of supported mp parameters
+					'q'              => array(
+						'config',
+						'syndicate-to',
+						'category',
+						'source',
+					), // List of supported query parameters
+				);
+				break;
+			case 'syndicate-to':
+				// return syndication targets with filter
+				$resp = array( 'syndicate-to' => static::get_syndicate_targets( $user_id ) );
+				break;
+			case 'category':
+				// https://github.com/indieweb/micropub-extensions/issues/5
+				$resp = array_merge(
+					get_tags( array( 'fields' => 'names' ) ),
+					get_terms(
+						array(
+							'taxonomy' => 'category',
+							'fields'   => 'names',
+						)
+					)
+				);
+				if ( array_key_exists( 'search', static::$input ) ) {
+					$search = static::$input['search'];
+					$resp   = array_values(
+						array_filter(
+							$resp,
+							function( $value ) use ( $search ) {
+								return ( false !== stripos( $value, $search ) );
+							}
 						)
 					);
-					if ( array_key_exists( 'search', static::$input ) ) {
-						$search = static::$input['search'];
-						$resp   = array_values(
-							array_filter(
-								$resp,
-								function( $value ) use ( $search ) {
-									return ( false !== stripos( $value, $search ) );
-								}
-							)
-						);
-					}
+				}
 
-					$resp = array( 'categories' => $resp );
-					break;
-				case 'source':
-					if ( array_key_exists( 'url', static::$input ) ) {
-						$post_id = url_to_postid( static::$input['url'] );
-						if ( ! $post_id ) {
-							return new WP_Micropub_Error( 'invalid_request', sprintf( 'not found: %1$s', static::$input['url'] ), 400 );
-						}
-						$resp = self::query( $post_id );
-					} else {
-						$numberposts = mp_get( static::$input, 'limit', 10 );
-						$posts       = get_posts(
-							array(
-								'posts_per_page' => $numberposts,
-								'fields'         => 'ids',
-							)
-						);
-						$resp        = array();
-						foreach ( $posts as $post ) {
-							$resp[] = self::query( $post );
-						}
+				$resp = array( 'categories' => $resp );
+				break;
+			case 'source':
+				if ( array_key_exists( 'url', static::$input ) ) {
+					$post_id = url_to_postid( static::$input['url'] );
+					if ( ! $post_id ) {
+						return new WP_Micropub_Error( 'invalid_request', sprintf( 'not found: %1$s', static::$input['url'] ), 400 );
 					}
+					$resp = self::query( $post_id );
+				} else {
+					$numberposts = mp_get( static::$input, 'limit', 10 );
+					$posts       = get_posts(
+						array(
+							'posts_per_page' => $numberposts,
+							'fields'         => 'ids',
+						)
+					);
+					$resp        = array();
+					foreach ( $posts as $post ) {
+						$resp[] = self::query( $post );
+					}
+				}
 
-					break;
-				default:
-					return new WP_Micropub_Error( 'invalid_request', 'unknown query', 400, static::$input );
-			}
+				break;
+			default:
+				return new WP_Micropub_Error( 'invalid_request', 'unknown query', 400, static::$input );
 		}
+		$resp = apply_filters( 'micropub_query', $resp, static::$input );
 
 		do_action( 'after_micropub', static::$input, null );
 		return new WP_REST_Response( $resp, 200 );

--- a/includes/class-micropub-media.php
+++ b/includes/class-micropub-media.php
@@ -260,6 +260,19 @@ class Micropub_Media {
 	// Responds to queries to the media endpoint
 	public static function query_handler( $request ) {
 		$permission = static::permissions_check( $request );
+		$params     = $request->get_query_params();
+		if ( array_key_exists( 'q', $params ) ) {
+			switch ( $params['q'] ) {
+				case 'config':
+					return new WP_REST_Response(
+						array(
+							'q' => array(),
+						),
+						200
+					);
+			}
+		}
+
 		if ( is_micropub_error( $permission ) ) {
 			return $permission;
 		}

--- a/micropub.php
+++ b/micropub.php
@@ -7,7 +7,7 @@
  * Author: Ryan Barrett
  * Author URI: https://snarfed.org/
  * Text Domain: micropub
- * Version: 2.0.2
+ * Version: 2.0.3
  */
 
 /* See README for supported filters and actions.

--- a/readme.md
+++ b/readme.md
@@ -45,9 +45,10 @@ Called during the handling of a Micropub request. The content generation functio
 `micropub_syndicate-to( $synd_urls, $user_id )`
 
 Called to generate the list of `syndicate-to` targets to return in response to a query. Returns `$synd_urls`, an array, possibly modified. This filter is empty by default
+
 `micropub_query( $resp, $input )`
 
-$resp defaults to null. If the return value is non-null, it should be an associative array that is encoded as JSON and will be returned in place of the normal micropub response.
+Allows you to replace a query response with your own customized version to add additional information
 
 `indieauth_scopes( $scopes )`
 
@@ -202,6 +203,17 @@ into markdown and saved to readme.md.
 
 
 ## Changelog 
+
+
+### 2.0.3 (2018-11-17) 
+* Fix issue where the after_micropub action could not see form encoded files by adding them as properties on upload
+* Fix issue in previous release where did not account for a null request sent by wpcli
+* Add search parameter to category
+* Wrap category query in categories key to be consistent with other query parameters
+* If a URL is not provided to the query source parameter it will return the last 10 posts or more/less with an optional parameter
+* Micropub query filter now called after default parameters are added rather than before so it can modify the defaults rather than replacing them.
+* Micropub config query now returns a list of supported mp parameters and supported q query parameters
+* Micropub media endpoint config query now returns an empty array indicating that it has no configuration parameters yet
 
 
 ### 2.0.2 (2018-11-12) 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: micropub, publish, indieweb, microformats
 Requires at least: 4.7
 Requires PHP: 5.3
 Tested up to: 4.9.8
-Stable tag: 2.0.2
+Stable tag: 2.0.3
 License: CC0
 License URI: http://creativecommons.org/publicdomain/zero/1.0/
 Donate link: -
@@ -51,9 +51,10 @@ Called during the handling of a Micropub request. The content generation functio
 `micropub_syndicate-to( $synd_urls, $user_id )`
 
 Called to generate the list of `syndicate-to` targets to return in response to a query. Returns `$synd_urls`, an array, possibly modified. This filter is empty by default
+
 `micropub_query( $resp, $input )`
 
-$resp defaults to null. If the return value is non-null, it should be an associative array that is encoded as JSON and will be returned in place of the normal micropub response.
+Allows you to replace a query response with your own customized version to add additional information
 
 `indieauth_scopes( $scopes )`
 
@@ -198,6 +199,16 @@ To automatically convert the readme.txt file to readme.md, you may, if you have 
 into markdown and saved to readme.md.
 
 == Changelog ==
+
+= 2.0.3 (2018-11-17) =
+* Fix issue where the after_micropub action could not see form encoded files by adding them as properties on upload
+* Fix issue in previous release where did not account for a null request sent by wpcli
+* Add search parameter to category
+* Wrap category query in categories key to be consistent with other query parameters
+* If a URL is not provided to the query source parameter it will return the last 10 posts or more/less with an optional parameter
+* Micropub query filter now called after default parameters are added rather than before so it can modify the defaults rather than replacing them.
+* Micropub config query now returns a list of supported mp parameters and supported q query parameters
+* Micropub media endpoint config query now returns an empty array indicating that it has no configuration parameters yet
 
 = 2.0.2 (2018-11-12) =
 * Fix issue with built-in auth and update compatibility testing


### PR DESCRIPTION
To address the issue that the after_micropub does not have access to the properties that came in by files in a form-encoded submission, the uploaded urls will be added so the properties can be accessed by the hook.

The search parameter was added to the category query, and it is now wrapped in key categories as agreed by the only support for it currently in client/endpoints. Preliminary support for query post list as well as the limit parameter for same.

The micropub_query filter now passes the plugin built in parameters so they can be added to rather than forcing a developer to create everything from scratch.

The media endpoint now has an empty q=config indicating it has no existing query parameters. The endpoint passes back the parameters it does support as well as the mp commands it supports.