### PR TITLE
Add settings ui for endpoints and update readme

### DIFF
--- a/includes/class-micropub-admin.php
+++ b/includes/class-micropub-admin.php
@@ -22,7 +22,7 @@ class Micropub_Admin {
 
 		// Register Setting
 		register_setting(
-			'micropub_writing',
+			'micropub',
 			'micropub_default_post_status', // Setting Name
 			array(
 				'type'              => 'string',
@@ -57,6 +57,7 @@ class Micropub_Admin {
 	 */
 	public static function admin_menu() {
 		$title = 'Micropub';
+		$cls   = get_called_class();
 		// If the IndieWeb Plugin is installed use its menu.
 		if ( class_exists( 'IndieWeb_Plugin' ) ) {
 			$options_page = add_submenu_page(
@@ -65,7 +66,7 @@ class Micropub_Admin {
 				$title,
 				'manage_options',
 				'micropub',
-				array( 'Micropub_Admin', 'settings_page' )
+				array( $cls, 'settings_page' )
 			);
 		} else {
 			$options_page = add_options_page(
@@ -73,7 +74,7 @@ class Micropub_Admin {
 				$title,
 				'manage_options',
 				'micropub',
-				array( 'Micropub_Admin', 'settings_page' )
+				array( $cls, 'settings_page' )
 			);
 		}
 

--- a/includes/class-micropub-authorize.php
+++ b/includes/class-micropub-authorize.php
@@ -34,6 +34,8 @@ class Micropub_Authorize {
 	public static function init() {
 		$cls = get_called_class();
 
+		add_action( 'admin_init', array( $cls, 'admin_init' ), 11 );
+
 		add_action( 'wp_head', array( $cls, 'html_header' ), 99 );
 		add_action( 'send_headers', array( $cls, 'http_header' ) );
 		add_filter( 'host_meta', array( $cls, 'jrd_links' ) );
@@ -45,6 +47,73 @@ class Micropub_Authorize {
 		add_filter( 'rest_authentication_errors', array( $cls, 'rest_authentication_errors' ), 10 );
 		add_filter( 'rest_post_dispatch', array( $cls, 'return_micropub_error' ), 10, 3 );
 
+				// Register Setting
+				register_setting(
+					'micropub',
+					'indieauth_authorization_endpoint', // Setting Name
+					array(
+						'type'              => 'string',
+						'description'       => 'IndieAuth Authorization Endpoint',
+						'sanitize_callback' => 'esc_url',
+						'show_in_rest'      => true,
+					)
+				);
+				// Register Setting
+				register_setting(
+					'micropub',
+					'indieauth_token_endpoint', // Setting Name
+					array(
+						'type'              => 'string',
+						'description'       => 'IndieAuth Token Endpoint',
+						'sanitize_callback' => 'esc_url',
+						'show_in_rest'      => true,
+					)
+				);
+
+	}
+
+	public static function admin_init() {
+		$cls  = get_called_class();
+		$page = 'micropub';
+				add_settings_section(
+					'micropub_authorize',
+					'Micropub Authorization Settings',
+					array( $cls, 'auth_settings' ),
+					$page
+				);
+				add_settings_field(
+					'indieauth_authorization_endpoint',
+					__( 'Authorization Endpoint', 'micropub' ),
+					array( $cls, 'endpoint_field' ),
+					$page,
+					'micropub_authorize',
+					array(
+						'label_for' => 'indieauth_authorization_endpoint',
+						'class'     => 'widefat',
+						'default'   => MICROPUB_AUTHENTICATION_ENDPOINT,
+					)
+				);
+				add_settings_field(
+					'indieauth_token_endpoint',
+					__( 'Token Endpoint', 'micropub' ),
+					array( $cls, 'endpoint_field' ),
+					$page,
+					'micropub_authorize',
+					array(
+						'label_for' => 'indieauth_token_endpoint',
+						'class'     => 'widefat',
+						'default'   => MICROPUB_TOKEN_ENDPOINT,
+					)
+				);
+	}
+
+
+	public static function endpoint_field( $args ) {
+			printf( '<label for="%1$s"><input id="%1$s" name="%1$s" type="url" value="%2$s" />', esc_attr( $args['label_for'] ), esc_url( get_option( $args['label_for'], $args['default'] ) ) );
+	}
+
+	public static function auth_settings() {
+			echo 'Server Settings for Indieauth';
 	}
 
 	public static function get_error() {

--- a/micropub.php
+++ b/micropub.php
@@ -7,7 +7,7 @@
  * Author: Ryan Barrett
  * Author URI: https://snarfed.org/
  * Text Domain: micropub
- * Version: 2.0.4
+ * Version: 2.0.5
  */
 
 /* See README for supported filters and actions.

--- a/readme.md
+++ b/readme.md
@@ -126,8 +126,8 @@ Install from the WordPress plugin directory. No setup needed.
 
 These configuration options can be enabled by adding them to your wp-config.php
 
-* `define('MICROPUB_AUTHENTICATION_ENDPOINT', 'https://indieauth.com/auth')` - Define a custom authentication endpoint.
-* `define('MICROPUB_TOKEN_ENDPOINT', 'https://tokens.indieauth.com/token')` - Define a custom token endpoint
+* `define('MICROPUB_AUTHENTICATION_ENDPOINT', 'https://indieauth.com/auth')` - Define a custom authentication endpoint. Can be overridden in the settings interface
+* `define('MICROPUB_TOKEN_ENDPOINT', 'https://tokens.indieauth.com/token')` - Define a custom token endpoint. Can be overridden in the settings interface.
 * `define('MICROPUB_NAMESPACE', 'micropub/1.0' )` - By default the namespace for micropub is micropub/1.0. This would allow you to change this for your endpoint
 * `define('MICROPUB_DISABLE_NAG', 1 ) - Disable notices for insecure sites
 * `define('MICROPUB_LOCAL_AUTH', 1 ) - Disable built in AUTH in favor of your own plugin. Recommend plugin developers use the filter `disable_micropub_auth` for this.
@@ -203,6 +203,11 @@ into markdown and saved to readme.md.
 
 
 ## Changelog 
+
+
+### 2.0.5 (2018-11-23) 
+* Move syndication trigger to after micropub hook in order to ensure final version is rendered before sending syndication
+* Add settings UI for alternate authorization endpoint and token endpoint which will be hidden if Indieauth plugin is enabled
 
 
 ### 2.0.4 (2018-11-17) 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: micropub, publish, indieweb, microformats
 Requires at least: 4.7
 Requires PHP: 5.3
 Tested up to: 4.9.8
-Stable tag: 2.0.4
+Stable tag: 2.0.5
 License: CC0
 License URI: http://creativecommons.org/publicdomain/zero/1.0/
 Donate link: -
@@ -128,8 +128,8 @@ Install from the WordPress plugin directory. No setup needed.
 
 These configuration options can be enabled by adding them to your wp-config.php
 
-* `define('MICROPUB_AUTHENTICATION_ENDPOINT', 'https://indieauth.com/auth')` - Define a custom authentication endpoint.
-* `define('MICROPUB_TOKEN_ENDPOINT', 'https://tokens.indieauth.com/token')` - Define a custom token endpoint
+* `define('MICROPUB_AUTHENTICATION_ENDPOINT', 'https://indieauth.com/auth')` - Define a custom authentication endpoint. Can be overridden in the settings interface
+* `define('MICROPUB_TOKEN_ENDPOINT', 'https://tokens.indieauth.com/token')` - Define a custom token endpoint. Can be overridden in the settings interface.
 * `define('MICROPUB_NAMESPACE', 'micropub/1.0' )` - By default the namespace for micropub is micropub/1.0. This would allow you to change this for your endpoint
 * `define('MICROPUB_DISABLE_NAG', 1 ) - Disable notices for insecure sites
 * `define('MICROPUB_LOCAL_AUTH', 1 ) - Disable built in AUTH in favor of your own plugin. Recommend plugin developers use the filter `disable_micropub_auth` for this.
@@ -199,6 +199,10 @@ To automatically convert the readme.txt file to readme.md, you may, if you have 
 into markdown and saved to readme.md.
 
 == Changelog ==
+
+= 2.0.5 (2018-11-23) =
+* Move syndication trigger to after micropub hook in order to ensure final version is rendered before sending syndication
+* Add settings UI for alternate authorization endpoint and token endpoint which will be hidden if Indieauth plugin is enabled
 
 = 2.0.4 (2018-11-17) =
 * Issues raised on prior release.

--- a/templates/micropub-settings.php
+++ b/templates/micropub-settings.php
@@ -2,8 +2,7 @@
 <h1>Micropub Options</h1>
 <form method="post" action="options.php">
 <?php
-	//add_settings_section callback is displayed here. For every new section we need to call settings_fields.
-	settings_fields("micropub_writing");
+	settings_fields("micropub");
 	// all the add_settings_field callbacks is displayed here
 	do_settings_sections("micropub");
 	


### PR DESCRIPTION
This adds in a settings UI for setting the auth endpoint and token endpoint, but only shows these options if the local authorization is loaded.