### PR TITLE
May 2019 Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
   - php: 7.0
   - php: 5.6
   - php: 5.4
+    env: WP_VERSION=4.9.9 WP_MULTISITE=0
+    # WordPress 5.2 removes support for WordPress 5.4. Testing for 4.9.9 as many people did not move to 5.0 due Gutenberg concerns
 before_script:
 - |
   # Remove Xdebug for a huge performance increase:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ matrix:
     env: WP_VERSION=latest WP_MULTISITE=0 WP_PLUGIN_DEPLOY=1
   - php: 7.0
   - php: 5.6
+    env: WP_VERSION=latest WP_MULTISITE=1
+  - php: 5.6
+    env: WP_VERSION=latest WP_MULTISITE=0
   - php: 5.4
     env: WP_VERSION=4.9.9 WP_MULTISITE=0
     # WordPress 5.2 removes support for WordPress 5.4. Testing for 4.9.9 as many people did not move to 5.0 due Gutenberg concerns

--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -854,35 +854,40 @@ class Micropub_Endpoint {
 			if ( ! isset( $args['meta_input'] ) ) {
 				$args['meta_input'] = array();
 			}
-			// $location = self::parse_geo_uri( $location );
 			if ( is_array( $location ) ) {
 				$props = $location['properties'];
 				if ( isset( $props['geo'] ) ) {
-					$args['meta_input']['geo_address'] = $props['label'][0];
-					$props                             = $props['geo'][0]['properties'];
+					if ( array_key_exists( 'label', $props ) ) {
+						$args['meta_input']['geo_address'] = $props['label'][0];
+					}
+					$props = $props['geo'][0]['properties'];
 				} else {
-					$parts                             = array(
-						mp_get( $props, 'name', true ),
-						mp_get( $props, 'street-address', true ),
-						mp_get( $props, 'locality', true ),
-						mp_get( $props, 'region', true ),
-						mp_get( $props, 'postal-code', true ),
-						mp_get( $props, 'country-name', true ),
+					$parts = array(
+						mp_get( $props, 'name', array(), true ),
+						mp_get( $props, 'street-address', array(), true ),
+						mp_get( $props, 'locality', array(), true ),
+						mp_get( $props, 'region', array(), true ),
+						mp_get( $props, 'postal-code', array(), true ),
+						mp_get( $props, 'country-name', array(), true ),
 					);
-					$args['meta_input']['geo_address'] = implode(
-						', ',
-						array_filter(
-							$parts,
-							function( $v ) {
-								return $v;
-							}
-						)
-					);
+					$parts = array_filter( $parts );
+					if ( ! empty( $parts ) ) {
+						$args['meta_input']['geo_address'] = implode(
+							', ',
+							array_filter(
+								$parts,
+								function( $v ) {
+									return $v;
+								}
+							)
+						);
+					}
 				}
-				$args['meta_input']['geo_latitude']  = mp_get( $props, 'latitude', true );
-				$args['meta_input']['geo_longitude'] = mp_get( $props, 'longitude', true );
-				$args['meta_input']['geo_altitude']  = mp_get( $props, 'altitude', true );
-				$args['meta_input']['geo_accuracy']  = mp_get( $props, 'accuracy', true );
+				foreach ( array( 'latitude', 'longitude', 'altitude', 'accuracy' ) as $property ) {
+					if ( array_key_exists( $property, $props ) ) {
+						$args['meta_input'][ 'geo_' . $property ] = $props[ $property ][0];
+					}
+				}
 			} elseif ( 'http' !== substr( $location, 0, 4 ) ) {
 				$args['meta_input']['geo_address'] = $location;
 			}

--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -862,12 +862,12 @@ class Micropub_Endpoint {
 					$props                             = $props['geo'][0]['properties'];
 				} else {
 					$parts                             = array(
-						$props['name'][0],
-						$props['street-address'][0],
-						$props['locality'][0],
-						$props['region'][0],
-						$props['postal-code'][0],
-						$props['country-name'][0],
+						mp_get( $props, 'name', true ),
+						mp_get( $props, 'street-address', true ),
+						mp_get( $props, 'locality', true ),
+						mp_get( $props, 'region', true ),
+						mp_get( $props, 'postal-code', true ),
+						mp_get( $props, 'country-name', true ),
 					);
 					$args['meta_input']['geo_address'] = implode(
 						', ',
@@ -879,10 +879,10 @@ class Micropub_Endpoint {
 						)
 					);
 				}
-				$args['meta_input']['geo_latitude']  = $props['latitude'][0];
-				$args['meta_input']['geo_longitude'] = $props['longitude'][0];
-				$args['meta_input']['geo_altitude']  = $props['altitude'][0];
-				$args['meta_input']['geo_accuracy']  = $props['accuracy'][0];
+				$args['meta_input']['geo_latitude']  = mp_get( $props, 'latitude', true );
+				$args['meta_input']['geo_longitude'] = mp_get( $props, 'longitude', true );
+				$args['meta_input']['geo_altitude']  = mp_get( $props, 'altitude', true );
+				$args['meta_input']['geo_accuracy']  = mp_get( $props, 'accuracy', true );
 			} elseif ( 'http' !== substr( $location, 0, 4 ) ) {
 				$args['meta_input']['geo_address'] = $location;
 			}

--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -191,6 +191,9 @@ class Micropub_Endpoint {
 	 * @return boolean|WP_Micropub_Error
 	**/
 	protected static function check_scope( $scope, $user_id = null ) {
+		if ( 'undelete' === $scope ) {
+			$scope = 'delete';
+		}
 		$inscope = in_array( $scope, static::$scopes, true ) || in_array( 'post', static::$scopes, true );
 		if ( ! $inscope ) {
 			return new WP_Micropub_Error( 'insufficient_scope', sprintf( 'scope insufficient to %1$s posts', $scope ), 401, static::$scopes );

--- a/includes/class-micropub-media.php
+++ b/includes/class-micropub-media.php
@@ -79,12 +79,27 @@ class Micropub_Media {
 	// Based on WP_REST_Attachments_Controller function of the same name
 	// TODO: Hook main endpoint functionality into and extend to use this class
 
-	public static function upload_from_file( $files, $name = null ) {
+	public static function upload_from_file( $files, $name = null, $headers = array() ) {
+
+		if ( empty( $files ) ) {
+			return new WP_Micropub_Error( 'invalid_request', 'No data supplied', 400 );
+		}
 
 		// Pass off to WP to handle the actual upload.
 		$overrides = array(
 			'test_form' => false,
 		);
+
+			// Verify hash, if given.
+		if ( ! empty( $headers['content_md5'] ) ) {
+			$content_md5 = array_shift( $headers['content_md5'] );
+			$expected    = trim( $content_md5 );
+			$actual      = md5_file( $files['file']['tmp_name'] );
+
+			if ( $expected !== $actual ) {
+				return new WP_Micropub_Error( 'invalid_request', 'Content hash did not match expected.', 412 );
+			}
+		}
 
 		// Bypasses is_uploaded_file() when running unit tests.
 		if ( defined( 'DIR_TESTDATA' ) && DIR_TESTDATA ) {
@@ -92,7 +107,7 @@ class Micropub_Media {
 		}
 
 		/** Include admin functions to get access to wp_handle_upload() */
-		require_once ABSPATH . 'wp-admin/includes/admin.php';
+		require_once ABSPATH . 'wp-admin/includes/file.php';
 
 		if ( $name && isset( $files[ $name ] ) && is_array( $files[ $name ] ) ) {
 			$files = $files[ $name ];
@@ -101,7 +116,8 @@ class Micropub_Media {
 		$file = wp_handle_upload( $files, $overrides );
 
 		if ( isset( $file['error'] ) ) {
-			return new WP_Micropub_Error( 'invalid_request', $file['error'], 500 );
+			error_log( wp_json_encode( $file['error'] ) );
+			return new WP_Micropub_Error( 'invalid_request', $file['error'], 500, $files );
 		}
 
 		return $file;
@@ -247,7 +263,7 @@ class Micropub_Media {
 		if ( empty( $files ) ) {
 			return new WP_Micropub_Error( 'invalid_request', 'No Files Attached', 400 );
 		} else {
-			$file = self::upload_from_file( $files, 'file' );
+			$file = self::upload_from_file( $files, 'file', $headers );
 		}
 
 		if ( is_micropub_error( $file ) ) {

--- a/includes/class-micropub-media.php
+++ b/includes/class-micropub-media.php
@@ -113,6 +113,12 @@ class Micropub_Media {
 			$files = $files[ $name ];
 		}
 
+		foreach ( $files as $key => $value ) {
+			if ( is_array( $value ) ) {
+				$files[ $key ] = array_shift( $value );
+			}
+		}
+
 		$file = wp_handle_upload( $files, $overrides );
 
 		if ( isset( $file['error'] ) ) {
@@ -310,6 +316,9 @@ class Micropub_Media {
 							'fields'         => 'ids',
 							'posts_per_page' => 10,
 							'order'          => 'DESC',
+							'date_query'     => array(
+								'after' => '1 hour ago',
+							),
 						)
 					);
 					if ( is_array( $attachments ) ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -23,10 +23,14 @@ if ( ! function_exists( 'getallheaders' ) ) {
 }
 
 if ( ! function_exists( 'mp_get' ) ) {
-	function mp_get( $array, $key, $default = array() ) {
-		if ( is_array( $array ) ) {
-			return isset( $array[ $key ] ) ? $array[ $key ] : $default;
+	function mp_get( $array, $key, $default = array(), $index = false ) {
+		$return = $default;
+		if ( is_array( $array ) && isset( $array[ $key ] ) ) {
+			$return = $array[ $key ];
 		}
-		return $default;
+		if ( $index && is_array( $return ) ) {
+			$return = $return[0];
+		}
+		return $return;
 	}
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -28,7 +28,7 @@ if ( ! function_exists( 'mp_get' ) ) {
 		if ( is_array( $array ) && isset( $array[ $key ] ) ) {
 			$return = $array[ $key ];
 		}
-		if ( $index && is_array( $return ) ) {
+		if ( $index && wp_is_numeric_array( $return ) ) {
 			$return = $return[0];
 		}
 		return $return;

--- a/micropub.php
+++ b/micropub.php
@@ -7,7 +7,7 @@
  * Author: Ryan Barrett
  * Author URI: https://snarfed.org/
  * Text Domain: micropub
- * Version: 2.0.10
+ * Version: 2.0.11
  */
 
 /* See README for supported filters and actions.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,9 +5,9 @@
 	<file>./micropub.php</file>
 	<file>./includes/</file>
 	<rule ref="PHPCompatibility"/>
-	<config name="testVersion" value="5.3-"/>
+	<config name="testVersion" value="5.4-"/>
 	<rule ref="WordPress-Core" />	
-	<config name="minimum_supported_wp_version" value="4.7"/>
+	<config name="minimum_supported_wp_version" value="4.9"/>
 	<rule ref="WordPress.Files.FileName">
 	<properties>
 	<property name="strict_class_file_names" value="false" />

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,12 @@
-A [Micropub](http://micropub.net/) server plugin. Available in the WordPress plugin directory at [wordpress.org/plugins/micropub](https://wordpress.org/plugins/micropub/).
+Micropub is an open API standard that is used to create posts on your site using third-party clients. Web apps and native apps (e.g. iPhone, Android) 
+can use Micropub to post short notes, photos, events or other posts to your own site, similar to a Twitter client posting to Twitter.com. 
 
 
 ## Description 
 
-[![Travis CI](https://travis-ci.org/indieweb/wordpress-micropub.svg?branch=master)](https://travis-ci.org/indieweb/wordpress-micropub)
+Adds [Micropub](http://micropub.net/) server support to WordPress. 
 
-> Micropub is an open API standard that is used to create posts on one's own domain using third-party clients. Web apps and native apps (e.g. iPhone, Android) can use Micropub to post short notes, photos, events or other posts to your own site, similar to a Twitter client posting to Twitter.com. 
+[![Travis CI](https://travis-ci.org/indieweb/wordpress-micropub.svg?branch=master)](https://travis-ci.org/indieweb/wordpress-micropub)
 
 Once you've installed and activated the plugin, try using [Quill](http://quill.p3k.io/) to create a new post on your site. It walks you through the steps and helps you troubleshoot if you run into any problems. A list of known Micropub clients are available [here](https://indieweb.org/Micropub/Clients)
 
@@ -13,6 +14,8 @@ Supports the [full W3C Micropub CR spec](https://www.w3.org/TR/micropub/) as of 
 
 As this allows the creation of posts without entering the WordPress admin, it is not subject to any Gutenberg compatibility concerns per se. Posts created will not have Gutenberg blocks
 as they were not created with Gutenberg, but otherwise there should be no issues at this time.
+
+Available in the WordPress plugin directory at [wordpress.org/plugins/micropub](https://wordpress.org/plugins/micropub/).
 
 
 ## License 
@@ -26,8 +29,7 @@ Supports the following [scope](https://indieweb.org/scope) parameters requested 
 * post (legacy) - Grants all user delegated access
 * create - Allows the client to create posts on behalf of the user
 * update - Allows the client to update posts on behalf of the user
-* delete - Allows the client to delete posts on behalf of the user
-* undelete - Allows the client to undelete posts on behalf of the user
+* delete - Allows the client to undelete/delete posts on behalf of the user
 * media  - Supports media for the media endpoint, but create or update also give media upload permissions
 
 
@@ -89,15 +91,17 @@ Stores [microformats2](http://microformats.org/wiki/microformats2) properties in
 Does *not* support multithreading. PHP doesn't really either, so it generally won't matter, but just for the record.
 
 Supports Experimental Extensions to Micropub:
-* [Post Status](https://indieweb.org/Micropub-extensions#Post_Status) - Either `published` or `draft`
-* [Visibility](https://indieweb.org/Micropub-extensions#Visibility) - Either `public` or `private`.
+* [Post Status](https://github.com/indieweb/micropub-extensions/issues/19) - Either `published` or `draft`
+* [Visibility](https://github.com/indieweb/micropub-extensions/issues/11) - Either `public` or `private`.
 * [Location Visiblity](https://indieweb.org/Micropub-extensions#Location_Visibility) - Either `public`, `private`, or `protected`
 * [Query for Post List](https://github.com/indieweb/micropub-extensions/issues/4) - Supports query for the last x number of posts. 
-* [Query for Support Queries](https://github.com/indieweb/micropub-extensions/issues/7) - Returns a list of query parameters the endpoint supports
+* [Query for Supported Queries](https://github.com/indieweb/micropub-extensions/issues/7) - Returns a list of query parameters the endpoint supports
 * [Query for Supported Properties](https://github.com/indieweb/micropub-extensions/issues/8) - Returns a list of which supported experimental properties the endpoint supports so the client can choose to hide unsupported ones.
+* [Discovery of Media Endpoint using Link Rel](https://github.com/indieweb/micropub-extensions/issues/15) - Adds a link header for the media endpoint
+* [Last Media Uploaded](https://github.com/indieweb/micropub-extensions/issues/10) - Supports querying for the last image uploaded ...set to within the last hour
 
 
-If an experimental property is not set to one of these options, the plugin will return HTTP 400 with body:
+If an experimental property is not set to one of the noted options, the plugin will return HTTP 400 with body:
 
     {
       "error": "invalid_request",
@@ -141,7 +145,7 @@ These configuration options can be enabled by adding them to your wp-config.php
 * `define('MICROPUB_TOKEN_ENDPOINT', 'https://tokens.indieauth.com/token')` - Define a custom token endpoint. Can be overridden in the settings interface.
 * `define('MICROPUB_NAMESPACE', 'micropub/1.0' )` - By default the namespace for micropub is micropub/1.0. This would allow you to change this for your endpoint
 * `define('MICROPUB_DISABLE_NAG', 1 ) - Disable notices for insecure sites
-* `define('MICROPUB_LOCAL_AUTH', 1 ) - Disable built in AUTH in favor of your own plugin. Recommend plugin developers use the filter `disable_micropub_auth` for this.
+* `define('MICROPUB_LOCAL_AUTH', 1 ) - Disable built in AUTH in favor of your own plugin.
 
 These configuration options can be enabled by setting them in the WordPress options table.
 * `indieauth_authorization_endpoint` - if set will override MICROPUB_AUTHENTICATION_ENDPOINT for setting a custom endpoint

--- a/readme.md
+++ b/readme.md
@@ -216,6 +216,13 @@ into markdown and saved to readme.md.
 ## Changelog 
 
 
+### 2.0.11 (2019-05-25) 
+* Fix issues with empty variables
+* Update last media query to limit itself to last hour
+* Undelete is now part of delete scope as there is no undelete scope
+* Address issue where properties in upload are single property arrays  
+
+
 ### 2.0.10 (2019-04-13) 
 * Fix issue with media not being attached to post 
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: indieweb, snarfed, dshanske
 Tags: micropub, publish, indieweb, microformats
 Requires at least: 4.7
 Requires PHP: 5.3
-Tested up to: 5.1.1
-Stable tag: 2.0.10
+Tested up to: 5.2
+Stable tag: 2.0.11
 License: CC0
 License URI: http://creativecommons.org/publicdomain/zero/1.0/
 Donate link: -
@@ -210,6 +210,12 @@ To automatically convert the readme.txt file to readme.md, you may, if you have 
 into markdown and saved to readme.md.
 
 == Changelog ==
+
+= 2.0.11 (2019-05-25) =
+* Fix issues with empty variables
+* Update last media query to limit itself to last hour
+* Undelete is now part of delete scope as there is no undelete scope
+* Address issue where properties in upload are single property arrays  
 
 = 2.0.10 (2019-04-13) =
 * Fix issue with media not being attached to post 

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Micropub ===
 Contributors: indieweb, snarfed, dshanske
 Tags: micropub, publish, indieweb, microformats
-Requires at least: 4.7
-Requires PHP: 5.3
+Requires at least: 4.9.9
+Requires PHP: 5.4
 Tested up to: 5.2
 Stable tag: 2.0.11
 License: CC0

--- a/readme.txt
+++ b/readme.txt
@@ -9,13 +9,14 @@ License: CC0
 License URI: http://creativecommons.org/publicdomain/zero/1.0/
 Donate link: -
 
-A [Micropub](http://micropub.net/) server plugin. Available in the WordPress plugin directory at [wordpress.org/plugins/micropub](https://wordpress.org/plugins/micropub/).
+Micropub is an open API standard that is used to create posts on your site using third-party clients. Web apps and native apps (e.g. iPhone, Android) 
+can use Micropub to post short notes, photos, events or other posts to your own site, similar to a Twitter client posting to Twitter.com. 
 
 == Description ==
 
-[![Travis CI](https://travis-ci.org/indieweb/wordpress-micropub.svg?branch=master)](https://travis-ci.org/indieweb/wordpress-micropub)
+Adds [Micropub](http://micropub.net/) server support to WordPress. 
 
-> Micropub is an open API standard that is used to create posts on one's own domain using third-party clients. Web apps and native apps (e.g. iPhone, Android) can use Micropub to post short notes, photos, events or other posts to your own site, similar to a Twitter client posting to Twitter.com. 
+[![Travis CI](https://travis-ci.org/indieweb/wordpress-micropub.svg?branch=master)](https://travis-ci.org/indieweb/wordpress-micropub)
 
 Once you've installed and activated the plugin, try using [Quill](http://quill.p3k.io/) to create a new post on your site. It walks you through the steps and helps you troubleshoot if you run into any problems. A list of known Micropub clients are available [here](https://indieweb.org/Micropub/Clients)
 
@@ -23,6 +24,8 @@ Supports the [full W3C Micropub CR spec](https://www.w3.org/TR/micropub/) as of 
 
 As this allows the creation of posts without entering the WordPress admin, it is not subject to any Gutenberg compatibility concerns per se. Posts created will not have Gutenberg blocks
 as they were not created with Gutenberg, but otherwise there should be no issues at this time.
+
+Available in the WordPress plugin directory at [wordpress.org/plugins/micropub](https://wordpress.org/plugins/micropub/).
 
 == License ==
 
@@ -34,8 +37,7 @@ Supports the following [scope](https://indieweb.org/scope) parameters requested 
 * post (legacy) - Grants all user delegated access
 * create - Allows the client to create posts on behalf of the user
 * update - Allows the client to update posts on behalf of the user
-* delete - Allows the client to delete posts on behalf of the user
-* undelete - Allows the client to undelete posts on behalf of the user
+* delete - Allows the client to undelete/delete posts on behalf of the user
 * media  - Supports media for the media endpoint, but create or update also give media upload permissions
 
 == WordPress details ==
@@ -94,15 +96,17 @@ Stores [microformats2](http://microformats.org/wiki/microformats2) properties in
 Does *not* support multithreading. PHP doesn't really either, so it generally won't matter, but just for the record.
 
 Supports Experimental Extensions to Micropub:
-* [Post Status](https://indieweb.org/Micropub-extensions#Post_Status) - Either `published` or `draft`
-* [Visibility](https://indieweb.org/Micropub-extensions#Visibility) - Either `public` or `private`.
+* [Post Status](https://github.com/indieweb/micropub-extensions/issues/19) - Either `published` or `draft`
+* [Visibility](https://github.com/indieweb/micropub-extensions/issues/11) - Either `public` or `private`.
 * [Location Visiblity](https://indieweb.org/Micropub-extensions#Location_Visibility) - Either `public`, `private`, or `protected`
 * [Query for Post List](https://github.com/indieweb/micropub-extensions/issues/4) - Supports query for the last x number of posts. 
-* [Query for Support Queries](https://github.com/indieweb/micropub-extensions/issues/7) - Returns a list of query parameters the endpoint supports
+* [Query for Supported Queries](https://github.com/indieweb/micropub-extensions/issues/7) - Returns a list of query parameters the endpoint supports
 * [Query for Supported Properties](https://github.com/indieweb/micropub-extensions/issues/8) - Returns a list of which supported experimental properties the endpoint supports so the client can choose to hide unsupported ones.
+* [Discovery of Media Endpoint using Link Rel](https://github.com/indieweb/micropub-extensions/issues/15) - Adds a link header for the media endpoint
+* [Last Media Uploaded](https://github.com/indieweb/micropub-extensions/issues/10) - Supports querying for the last image uploaded ...set to within the last hour
 
 
-If an experimental property is not set to one of these options, the plugin will return HTTP 400 with body:
+If an experimental property is not set to one of the noted options, the plugin will return HTTP 400 with body:
 
     {
       "error": "invalid_request",
@@ -143,7 +147,7 @@ These configuration options can be enabled by adding them to your wp-config.php
 * `define('MICROPUB_TOKEN_ENDPOINT', 'https://tokens.indieauth.com/token')` - Define a custom token endpoint. Can be overridden in the settings interface.
 * `define('MICROPUB_NAMESPACE', 'micropub/1.0' )` - By default the namespace for micropub is micropub/1.0. This would allow you to change this for your endpoint
 * `define('MICROPUB_DISABLE_NAG', 1 ) - Disable notices for insecure sites
-* `define('MICROPUB_LOCAL_AUTH', 1 ) - Disable built in AUTH in favor of your own plugin. Recommend plugin developers use the filter `disable_micropub_auth` for this.
+* `define('MICROPUB_LOCAL_AUTH', 1 ) - Disable built in AUTH in favor of your own plugin.
 
 These configuration options can be enabled by setting them in the WordPress options table.
 * `indieauth_authorization_endpoint` - if set will override MICROPUB_AUTHENTICATION_ENDPOINT for setting a custom endpoint


### PR DESCRIPTION
* Fix travis tests to account for minimum PHP Requirements
* Additional PHP notice fixes
* Bump minimum requirements to PHP5.4 and WordPress 4.9 - reasoning behind this is that this would be consistent with the people who didn't want to upgrade to WordPress 5 due Gutenberg. 4.9 dates from November 2017, so already nearly 2 years old. 
* Indigenous for Android was not working for media endpoint uploads and this now addresses a fix.
* There is no one using an undelete scope. So, undelete now maps to delete. More in scopes in a future version.
* The q=last parameter has been adjusted to only look for the last image within the hour as opposed to all time as Quill would try to embed something every time.