### PR TITLE
Timezone Fix

### DIFF
--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -695,10 +695,10 @@ class Micropub_Endpoint {
 				if ( empty( $tz_string ) ) {
 					$tz_string = 'UTC';
 				}
-				$date->setTimeZone( new DateTimeZone( $tz_string ) );
 				$tz = $date->getTimezone();
 				// Pass this argument to the filter for use
 				$args['timezone']  = $tz->getName();
+				$date->setTimeZone( new DateTimeZone( $tz_string ) );
 				$args['post_date'] = $date->format( 'Y-m-d H:i:s' );
 				$date->setTimeZone( new DateTimeZone( 'GMT' ) );
 				$args['post_date_gmt'] = $date->format( 'Y-m-d H:i:s' );

--- a/micropub.php
+++ b/micropub.php
@@ -7,7 +7,7 @@
  * Author: Ryan Barrett
  * Author URI: https://snarfed.org/
  * Text Domain: micropub
- * Version: 2.0.11
+ * Version: 2.0.12
  */
 
 /* See README for supported filters and actions.

--- a/readme.md
+++ b/readme.md
@@ -220,6 +220,10 @@ into markdown and saved to readme.md.
 ## Changelog 
 
 
+### 2.0.12 (2019-xx-xx ) 
+* Fix bug where timezone meta key was always set to website timezone instead of provided one
+
+
 ### 2.0.11 (2019-05-25) 
 * Fix issues with empty variables
 * Update last media query to limit itself to last hour

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: indieweb, snarfed, dshanske
 Tags: micropub, publish, indieweb, microformats
 Requires at least: 4.9.9
 Requires PHP: 5.4
-Tested up to: 5.2
-Stable tag: 2.0.11
+Tested up to: 5.2.3
+Stable tag: 2.0.12
 License: CC0
 License URI: http://creativecommons.org/publicdomain/zero/1.0/
 Donate link: -
@@ -214,6 +214,9 @@ To automatically convert the readme.txt file to readme.md, you may, if you have 
 into markdown and saved to readme.md.
 
 == Changelog ==
+
+= 2.0.12 (2019-xx-xx ) =
+* Fix bug where timezone meta key was always set to website timezone instead of provided one
 
 = 2.0.11 (2019-05-25) =
 * Fix issues with empty variables


### PR DESCRIPTION
I added a line to the plugin previously that derived the timezone and passed it as an argument. However, it was always overridden by the default timezone. This fixes that. It is only used by Simple Location to set the display.