### PR TITLE
Image Meta

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -222,6 +222,7 @@ into markdown and saved to readme.md.
 
 ### 2.0.12 (2019-xx-xx ) 
 * Fix bug where timezone meta key was always set to website timezone instead of provided one
+* Fix issue where title and caption were not being set for images by adopting code from WordPress core
 
 
 ### 2.0.11 (2019-05-25) 

--- a/readme.txt
+++ b/readme.txt
@@ -217,6 +217,7 @@ into markdown and saved to readme.md.
 
 = 2.0.12 (2019-xx-xx ) =
 * Fix bug where timezone meta key was always set to website timezone instead of provided one
+* Fix issue where title and caption were not being set for images by adopting code from WordPress core
 
 = 2.0.11 (2019-05-25) =
 * Fix issues with empty variables


### PR DESCRIPTION
Noticed that the image title and caption isn't being set out of the EXIF/IPTC data.

Compared our insert_attachment function with Core. They look for image metadata on all files without checking to see if it is an image or not. While I'm not thrilled with that, if Core does it, I'll accept it for now.

So now the title and caption will be set automatically in line with what users would get from uploading directly in the backend.