### PR TITLE
Update Travis Tests to Better Targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,6 @@ php:
   - 7.4
 jobs:
   include:
-  - stage: multisitetest
-    env: WP_VERSION=latest WP_MULTISITE=1
-    php: 7.4
   - stage: previousversion
     php: 7.4
     env: WP_VERSION=5.3 WP_MULTISITE=0
@@ -48,7 +45,7 @@ before_script:
   # Install the specified version of PHPUnit depending on the PHP version:
   if [[ "$WP_TRAVISCI" == "travis:phpunit" ]]; then
     case "$TRAVIS_PHP_VERSION" in
-      7.4|7.2|7.1|nightly)
+      7.4|7.3|7.2|7.1|nightly)
         echo "Using PHPUnit 7.x"
         composer global require "phpunit/phpunit:^7"
         ;;

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,21 +14,22 @@ env:
   - WP_VERSION=latest WP_MULTISITE=0
   global:
   - WP_TRAVISCI=travis:phpunit
-  - SVN_REPO: https://plugins.svn.wordpress.org/micropub/
-matrix:
+php:
+  - 5.6
+  - 7.0
+  - 7.2
+  - 7.3
+  - 7.4
+jobs:
   include:
-  - php: 7.4
-    env: WP_VERSION=latest WP_MULTISITE=0 WP_PLUGIN_DEPLOY=1
-  - php: 7.4
-    env: WP_VERSION=latest WP_MULTISITE=1 WP_PLUGIN_DEPLOY=1
-  - php: 7.2
-    env: WP_VERSION=latest WP_MULTISITE=0 WP_PLUGIN_DEPLOY=1
-  - php: 7.0
-  - php: 5.6
+  - stage: multisitetest
     env: WP_VERSION=latest WP_MULTISITE=1
-  - php: 5.6
-    env: WP_VERSION=latest WP_MULTISITE=0
-  - php: 5.6
+    php: 7.4
+  - stage: previousversion
+    php: 7.4
+    env: WP_VERSION=5.3 WP_MULTISITE=0
+  - stage: oldestsupport
+    php: 5.6
     env: WP_VERSION=4.9.9 WP_MULTISITE=0
     # WordPress 5.2 removes support for WordPress 5.4. Testing for 4.9.9 as many people did not move to 5.0 due Gutenberg concerns
 before_script:
@@ -47,7 +48,11 @@ before_script:
   # Install the specified version of PHPUnit depending on the PHP version:
   if [[ "$WP_TRAVISCI" == "travis:phpunit" ]]; then
     case "$TRAVIS_PHP_VERSION" in
-      7.4|7.2|7.1|7.0|nightly)
+      7.4|7.2|7.1|nightly)
+        echo "Using PHPUnit 7.x"
+        composer global require "phpunit/phpunit:^7"
+        ;;
+      7.0|nightly)
         echo "Using PHPUnit 6.x"
         composer global require "phpunit/phpunit:^6"
         ;;

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,7 @@
 	convertWarningsToExceptions="true"
 	>
 	<testsuites>
-		<testsuite>
+		<testsuite name="WordPress Micropub Plugin">
 			<directory prefix="test" suffix=".php">./tests/</directory>
 		</testsuite>
 	</testsuites>


### PR DESCRIPTION
This switches to a staged testing. The system will test the latest version against PHP5.6-7.4 and then it will test the previous version of WordPress, and the oldest supported versions of WordPress and PHP together.