### PR TITLE
Authorication Tweaks and Testing Fixes

### DIFF
--- a/includes/class-micropub-base.php
+++ b/includes/class-micropub-base.php
@@ -14,9 +14,9 @@ abstract class Micropub_Base {
 		return defined( MICROPUB_NAMESPACE ) ? MICROPUB_NAMESPACE : 'micropub/1.0';
 	}
 
-	abstract public static function get_rel();
+	abstract public function get_rel();
 
-	abstract public static function get_route( $slash = false );
+	abstract public function get_route( $slash = false );
 
 	public static function get_endpoint() {
 		return rest_url( static::get_route() );

--- a/includes/class-micropub-base.php
+++ b/includes/class-micropub-base.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * Micropub Baseb Endpoint Class
+ */
+abstract class Micropub_Base {
+	// associative array.
+	protected static $micropub_auth_response = array();
+
+	// Array of Scopes
+	protected static $scopes = array();
+
+	public static function get_namespace() {
+		return defined( MICROPUB_NAMESPACE ) ? MICROPUB_NAMESPACE : 'micropub/1.0';
+	}
+
+	abstract public static function get_rel();
+
+	abstract public static function get_route( $slash = false );
+
+	public static function get_endpoint() {
+		return rest_url( static::get_route() );
+	}
+
+	/**
+	 * The autodicovery meta tags
+	 */
+	public static function html_header() {
+		// phpcs:ignore
+		printf( '<link rel="%1$s" href="%2$s" />' . PHP_EOL, static::get_rel(), static::get_endpoint() );
+	}
+
+	public static function header( $header, $value ) {
+		header( $header . ': ' . $value, false );
+	}
+
+	/**
+	 * The autodicovery http-header
+	 */
+	public static function http_header() {
+		static::header( 'Link', sprintf( '<%1$s>; rel="%2$s"', static::get_endpoint(), static::get_rel() ) );
+	}
+
+	/**
+	 * Generates webfinger/host-meta links
+	 */
+	public static function jrd_links( $array ) {
+		$array['links'][] = array(
+			'rel'  => static::get_rel(),
+			'href' => static::get_endpoint(),
+		);
+		return $array;
+	}
+
+
+	public static function return_micropub_error( $response, $handler, $request ) {
+		if ( static::get_route() !== $request->get_route() ) {
+			return $response;
+		}
+		if ( is_wp_error( $response ) ) {
+			return micropub_wp_error( $response );
+		}
+		return $response;
+	}
+
+	public static function log_error( $message, $name = 'Micropub' ) {
+		if ( empty( $message ) || defined( 'DIR_TESTDATA' ) ) {
+			return false;
+		}
+		if ( is_array( $message ) || is_object( $message ) ) {
+			$message = wp_json_encode( $message );
+		}
+
+		return error_log( sprintf( '%1$s: %2$s', $name, $message ) ); // phpcs:ignore
+	}
+
+	public static function get( $array, $key, $default = array() ) {
+		if ( is_array( $array ) ) {
+			return isset( $array[ $key ] ) ? $array[ $key ] : $default;
+		}
+		return $default;
+	}
+
+	public static function load_auth() {
+		// Check if logged in
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error( 'forbidden', 'Unauthorized', array( 'status' => 403 ) );
+		}
+
+		static::$micropub_auth_response = micropub_get_response();
+		static::$scopes                 = micropub_get_scopes();
+
+		// If there is no auth response this is cookie authentication which should be rejected
+		// https://www.w3.org/TR/micropub/#authentication-and-authorization - Requests must be authenticated by token
+		if ( empty( static::$micropub_auth_response ) ) {
+			return new WP_Error( 'unauthorized', 'Cookie Authentication is not permitted', array( 'status' => 401 ) );
+		}
+		return true;
+	}
+
+	public static function check_query_permissions( $request ) {
+		$auth = self::load_auth();
+		if ( is_wp_error( $auth ) ) {
+			return $auth;
+		}
+		$query = $request->get_param( 'q' );
+		if ( ! $query ) {
+			return new WP_Error( 'invalid_request', 'Missing Query Parameter', array( 'status' => 400 ) );
+		}
+
+		return true;
+	}
+
+	protected static function check_error( $result ) {
+		if ( ! $result ) {
+			return new WP_Micropub_Error( 'invalid_request', $result, 400 );
+		} elseif ( is_wp_error( $result ) ) {
+			return micropub_wp_error( $result );
+		}
+		return $result;
+	}
+}
+

--- a/includes/class-micropub-base.php
+++ b/includes/class-micropub-base.php
@@ -14,9 +14,14 @@ abstract class Micropub_Base {
 		return defined( MICROPUB_NAMESPACE ) ? MICROPUB_NAMESPACE : 'micropub/1.0';
 	}
 
-	abstract public function get_rel();
+	public static function get_rel() {
+		return 'micropub';
+	}
 
-	abstract public function get_route( $slash = false );
+	public static function get_route( $slash = false ) {
+		$return = static::get_namespace() . '/endpoint';
+		return $slash ? '/' . $return : $return;
+	}
 
 	public static function get_endpoint() {
 		return rest_url( static::get_route() );

--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -37,16 +37,6 @@ class Micropub_Endpoint extends Micropub_Base {
 		add_filter( 'rest_request_after_callbacks', array( static::class, 'return_micropub_error' ), 10, 3 );
 	}
 
-
-	public function get_rel() {
-		return 'micropub';
-	}
-
-	public function get_route( $slash = false ) {
-		$return = static::get_namespace() . '/endpoint';
-		return $slash ? '/' . $return : $return;
-	}
-
 	public static function get( $array, $key, $default = array() ) {
 		if ( is_array( $array ) ) {
 			return isset( $array[ $key ] ) ? $array[ $key ] : $default;

--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -664,7 +664,7 @@ class Micropub_Endpoint extends Micropub_Base {
 		}
 
 		if ( isset( $props['published'] ) ) {
-			$date = new DateTimeImmutable( $props['published'][0] );
+			$date = new DateTime( $props['published'][0] );
 			// If for whatever reason the date cannot be parsed do not include one which defaults to now
 			if ( $date ) {
 				$wptz = wp_timezone();
@@ -679,7 +679,7 @@ class Micropub_Endpoint extends Micropub_Base {
 		}
 
 		if ( isset( $props['updated'] ) ) {
-			$date = new DateTimeImmutable( $props['updated'][0] );
+			$date = new DateTime( $props['updated'][0] );
 			// If for whatever reason the date cannot be parsed do not include one which defaults to now
 			if ( $date ) {
 				$wptz = wp_timezone();

--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -101,12 +101,14 @@ class Micropub_Endpoint {
 	}
 
 	public static function load_auth() {
-		static::$micropub_auth_response = apply_filters( 'indieauth_response', static::$micropub_auth_response );
-		static::$scopes                 = apply_filters( 'indieauth_scopes', static::$scopes );
-		// Every user should have this capability which reflects the ability to access your user profile and the admin dashboard
-		if ( ! current_user_can( 'read' ) ) {
+
+		// Check if logged in
+		if ( ! is_user_logged_in() ) {
 			return new WP_Error( 'forbidden', 'Unauthorized', array( 'status' => 403 ) );
 		}
+
+		static::$micropub_auth_response = micropub_get_response();
+		static::$scopes                 = micropub_get_scopes();
 
 		// If there is no auth response this is cookie authentication which should be rejected
 		// https://www.w3.org/TR/micropub/#authentication-and-authorization - Requests must be authenticated by token

--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -38,11 +38,11 @@ class Micropub_Endpoint extends Micropub_Base {
 	}
 
 
-	public static function get_rel() {
+	public function get_rel() {
 		return 'micropub';
 	}
 
-	public static function get_route( $slash = false ) {
+	public function get_route( $slash = false ) {
 		$return = static::get_namespace() . '/endpoint';
 		return $slash ? '/' . $return : $return;
 	}

--- a/includes/class-micropub-error.php
+++ b/includes/class-micropub-error.php
@@ -11,7 +11,7 @@ class WP_Micropub_Error extends WP_REST_Response {
 		);
 		$data = array_filter( $data );
 		$this->set_data( $data );
-		if ( WP_DEBUG ) {
+		if ( WP_DEBUG && ! defined( 'DIR_TESTDATA' ) ) {
 			error_log( $this->to_log() ); // phpcs:ignore
 		}
 
@@ -30,7 +30,7 @@ class WP_Micropub_Error extends WP_REST_Response {
 			$data['error_description'],
 			array(
 				'status' => $status,
-				'data'   => $data['data'],
+				'data'   => mp_get( $data, 'data' ),
 			)
 		);
 	}

--- a/includes/class-micropub-media.php
+++ b/includes/class-micropub-media.php
@@ -21,11 +21,11 @@ class Micropub_Media extends Micropub_Base {
 
 	}
 
-	public function get_rel() {
+	public static function get_rel() {
 		return 'micropub_media';
 	}
 
-	public function get_route( $slash = false ) {
+	public static function get_route( $slash = false ) {
 		$return = static::get_namespace() . '/media';
 		return $slash ? '/' . $return : $return;
 	}

--- a/includes/class-micropub-media.php
+++ b/includes/class-micropub-media.php
@@ -73,7 +73,7 @@ class Micropub_Media {
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( static::class, 'upload_handler' ),
-					'permission_callback' => array( static::class, 'check_post_permissions' ),
+					'permission_callback' => array( static::class, 'check_create_permissions' ),
 				),
 				array(
 					'methods'             => WP_REST_Server::READABLE,
@@ -114,7 +114,7 @@ class Micropub_Media {
 		return true;
 	}
 
-	public static function check_post_permissions( $request ) {
+	public static function check_create_permissions( $request ) {
 		$auth = self::load_auth();
 		if ( is_wp_error( $auth ) ) {
 			return $auth;
@@ -124,6 +124,7 @@ class Micropub_Media {
 			$error = new WP_Micropub_Error( 'insufficient_scope', 'You do not have permission to create or upload media', 403 );
 			return $error->to_wp_error();
 		}
+		return true;
 	}
 
 	// Based on WP_REST_Attachments_Controller function of the same name
@@ -333,7 +334,7 @@ class Micropub_Media {
 
 	// Responds to queries to the media endpoint
 	public static function query_handler( $request ) {
-		$params     = $request->get_query_params();
+		$params = $request->get_query_params();
 		if ( array_key_exists( 'q', $params ) ) {
 			switch ( $params['q'] ) {
 				case 'config':

--- a/includes/class-micropub-media.php
+++ b/includes/class-micropub-media.php
@@ -21,11 +21,11 @@ class Micropub_Media extends Micropub_Base {
 
 	}
 
-	public static function get_rel() {
+	public function get_rel() {
 		return 'micropub_media';
 	}
 
-	public static function get_route( $slash = false ) {
+	public function get_route( $slash = false ) {
 		$return = static::get_namespace() . '/media';
 		return $slash ? '/' . $return : $return;
 	}

--- a/includes/class-micropub-render.php
+++ b/includes/class-micropub-render.php
@@ -63,7 +63,7 @@ class Micropub_Render {
 			$name    = $checkin['properties']['name'][0];
 			$urls    = $checkin['properties']['url'];
 			$lines[] = '<p>Checked into <a class="h-card p-location" href="' .
-				( $urls[1] ? $urls[1] : $urls[0] ) . '">' . $name . '</a>.</p>';
+				( isset( $urls[1] ) ? $urls[1] : $urls[0] ) . '">' . $name . '</a>.</p>';
 		}
 
 		if ( isset( $props['rsvp'] ) ) {
@@ -101,7 +101,7 @@ class Micropub_Render {
 	 * Generates and returns a string h-event.
 	 */
 	private static function generate_event( $input ) {
-		$props   = $input['replace'] ? $input['replace'] : $input['properties'];
+		$props   = mp_get( $input, 'replace', mp_get( $input, 'properties' ) );
 		$lines[] = '<div class="h-event">';
 
 		if ( isset( $props['name'] ) ) {

--- a/includes/class-micropub-render.php
+++ b/includes/class-micropub-render.php
@@ -112,7 +112,7 @@ class Micropub_Render {
 		$times   = array();
 		foreach ( array( 'start', 'end' ) as $cls ) {
 			if ( isset( $props[ $cls ][0] ) ) {
-				$datetime = new DateTime( $props[ $cls ][0] );
+				$datetime = new DateTimeImmutable( $props[ $cls ][0] );
 				$times[]  = '<time class="dt-' . $cls . '" datetime="' .
 					$datetime->format( DATE_W3C ) . '">' . $datetime->format( DATE_W3C ) . '</time>';
 			}

--- a/includes/compat-functions.php
+++ b/includes/compat-functions.php
@@ -5,12 +5,12 @@ if ( ! function_exists( 'current_datetime' ) ) {
 	/**
 	 * Retrieves the current time as an object with the timezone from settings.
 	 *
-	 * @since 5.3.0 - Backported to Micropub and DateTime used for pre PHP 5.5 compatibility for new
+	 * @since 5.3.0 - Backported to Micropub
 	 *
-	 * @return DateTime Date and time object.
+	 * @return DateTimeImmutable Date and time object.
 	 */
 	function current_datetime() {
-		return new DateTime( 'now', wp_timezone() );
+		return new DateTimeImmutable( 'now', wp_timezone() );
 	}
 }
 
@@ -20,11 +20,11 @@ if ( ! function_exists( 'get_post_datetime' ) ) {
 	 *
 	 * The object will be set to the timezone from WordPress settings.
 	 *
-	 * @since 5.3.0 - backported to Micropub and returns as a DateTime not DateTimeImmutable object for pre PHP 5.5 compat
+	 * @since 5.3.0 - backported to Micropub
 	 *
 	 * @param int|WP_Post $post  Optional. WP_Post object or ID. Default is global `$post` object.
 	 * @param string      $field Optional. Post field to use. Accepts 'date' or 'modified'.
-	 * @return DateTime|false Time object on success, false on failure.
+	 * @return DateTimeImmutable|false Time object on success, false on failure.
 	 */
 	function get_post_datetime( $post = null, $field = 'date' ) {
 		$post = get_post( $post );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -28,7 +28,7 @@ if ( ! function_exists( 'mp_get' ) ) {
 		if ( is_array( $array ) && isset( $array[ $key ] ) ) {
 			$return = $array[ $key ];
 		}
-		if ( $index && wp_is_numeric_array( $return ) ) {
+		if ( $index && wp_is_numeric_array( $return ) && ! empty( $return ) ) {
 			$return = $return[0];
 		}
 		return $return;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -48,3 +48,16 @@ if ( ! function_exists( 'mp_filter' ) ) {
 		);
 	}
 }
+
+if ( ! function_exists( 'micropub_get_response' ) ) {
+	function micropub_get_response() {
+		return apply_filters( 'indieauth_response', null );
+	}
+}
+
+if ( ! function_exists( 'micropub_get_scopes' ) ) {
+	function micropub_get_scopes() {
+		return apply_filters( 'indieauth_scopes', null );
+	}
+}
+

--- a/micropub.php
+++ b/micropub.php
@@ -43,6 +43,9 @@ if ( class_exists( 'IndieAuth_Plugin' ) ) {
 	// Error Handling Class
 	require_once plugin_dir_path( __FILE__ ) . 'includes/class-micropub-error.php';
 
+	// Endpoint Base Class.
+	require_once plugin_dir_path( __FILE__ ) . 'includes/class-micropub-base.php';
+
 	// Media Endpoint and Handling Functions
 	require_once plugin_dir_path( __FILE__ ) . 'includes/class-micropub-media.php';
 

--- a/micropub.php
+++ b/micropub.php
@@ -7,7 +7,7 @@
  * Author: IndieWeb WordPress Outreach Club
  * Author URI: https://indieweb.org/WordPress_Outreach_Club
  * Text Domain: micropub
- * Version: 2.2.2
+ * Version: 2.2.3
  */
 
 /* See README for supported filters and actions.

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,9 @@ Adds [Micropub](http://micropub.net/) server support to WordPress.
 
 Micropub is an open API standard that is used to create posts on your site using third-party clients. Web apps and native apps (e.g. iPhone, Android) can use Micropub to post short notes, photos, events or other posts to your own site, similar to a Twitter client posting to Twitter.com. Requires the IndieAuth plugin for authentication.
 
-[![Travis CI](https://travis-ci.org/indieweb/wordpress-micropub.svg?branch=master)](https://travis-ci.org/indieweb/wordpress-micropub)
+[![Travis CI](https://travis-ci.org/indieweb/wordpress-micropub.svg?branch
+
+### master)](https://travis-ci.org/indieweb/wordpress-micropub)
 
 Once you've installed and activated the plugin, try using [Quill](http://quill.p3k.io/) to create a new post on your site. It walks you through the steps and helps you troubleshoot if you run into any problems. A list of known Micropub clients are available [here](https://indieweb.org/Micropub/Clients)
 
@@ -33,7 +35,9 @@ Called before handling a Micropub request. Returns `$input`, possibly modified.
 
 Called during the handling of a Micropub request. The content generation function is attached to this filter by default. Returns `$post_content`, possibly modified.
 
-`micropub_post_type( $post_type = 'post', $input )`
+`micropub_post_type( $post_type 
+
+### 'post', $input )`
 
 Called during the creation of a Micropub post. This defaults to post, but allows for setting Micropub posts to a custom post type.
 
@@ -63,7 +67,9 @@ This returns the token auth response from a plugin implementing IndieAuth. This 
 
 ...and two hooks:
 
-`after_micropub( $input, $wp_args = null)`
+`after_micropub( $input, $wp_args 
+
+### null)`
 
 Called after handling a Micropub request. Not called if the request fails (ie doesn't return HTTP 2xx).
 
@@ -104,7 +110,9 @@ Supports Proposed Extensions to Micropub:
 
 Deprecated Extensions still Supported:
 
-* [Last Media Uploaded](https://github.com/indieweb/micropub-extensions/issues/10) - Supports querying for the last image uploaded ...set to within the last hour. This was superseded by supporting `q=source&limit=1` on the media endpoint.
+* [Last Media Uploaded](https://github.com/indieweb/micropub-extensions/issues/10) - Supports querying for the last image uploaded ...set to within the last hour. This was superseded by supporting `q=source&limit
+
+### 1` on the media endpoint.
 
 Extensions Supported by Other Plugins:
 
@@ -198,6 +206,13 @@ To automatically convert the readme.txt file to readme.md, you may, if you have 
 into markdown and saved to readme.md.
 
 ## Changelog
+
+### 2.2.3 (2020-09-08 )
+
+* Deduplicated endpoint test code from endpoint and media endpoint classes.
+* Removed error suppression revealing several notices that had been hidden. Fixed warning notices.
+* Abstract request for scope and response into functions to avoid calling the actual filter as this may be deprecated in future.
+* Switch check in permissions to whether a user was logged in.
 
 ### 2.2.2 (2020-08-23 )
 
@@ -382,7 +397,9 @@ media endpoint.
 
 ### 0.2
 
-* Support more Micropub properties: `photo`, `like-of`, `repost-of`, `in-reply-to`, `rsvp`, `location`, `category`, `h=event`.
+* Support more Micropub properties: `photo`, `like-of`, `repost-of`, `in-reply-to`, `rsvp`, `location`, `category`, `h
+
+### event`.
 
 * Check but don't require access tokens on localhost.
 * Better error handling.

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: indieweb, snarfed, dshanske
 Tags: micropub, publish, indieweb, microformats
 Requires at least: 4.9.9
 Requires PHP: 5.6
-Tested up to: 5.5
-Stable tag: 2.2.2
+Tested up to: 5.5.1
+Stable tag: 2.2.3
 License: CC0
 License URI: http://creativecommons.org/publicdomain/zero/1.0/
 Donate link: -
@@ -208,6 +208,12 @@ To automatically convert the readme.txt file to readme.md, you may, if you have 
 into markdown and saved to readme.md.
 
 == Changelog ==
+
+= 2.2.3 (2020-09-08 ) =
+* Deduplicated endpoint test code from endpoint and media endpoint classes.
+* Removed error suppression revealing several notices that had been hidden. Fixed warning notices.
+* Abstract request for scope and response into functions to avoid calling the actual filter as this may be deprecated in future.
+* Switch check in permissions to whether a user was logged in.
 
 = 2.2.2 (2020-08-23 ) =
 * Fixed and updated testing environment

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,7 +7,7 @@
 
 require dirname( __FILE__ ) . '/class-indieauth-plugin.php';
 
-define( 'WP_DEBUG', false );
+// define( 'WP_DEBUG', false );
 define( 'DIR_MEDIATESTDATA', dirname( __FILE__ ) . '/data' );
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
@@ -34,3 +34,5 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';
+
+require dirname( __FILE__ ) . '/class-micropub-unit-test-case.php';

--- a/tests/class-micropub-unit-test-case.php
+++ b/tests/class-micropub-unit-test-case.php
@@ -1,0 +1,99 @@
+<?php
+/* Endpoint Tests */
+
+class Micropub_UnitTestCase extends WP_UnitTestCase {
+
+
+	protected static $author_id;
+	protected static $subscriber_id;
+	protected static $scopes;
+
+	// Micropub Auth Response, based on https://tokens.indieauth.com/
+	protected static $micropub_auth_response = array(
+		'me'        => 'http://tacos.com', // taken from WordPress' tests/user.php
+		'client_id' => 'https://example.com',
+		'scope'     => 'create update delete',
+		'issued_at' => 1399155608,
+		'nonce'     => 501884823,
+	);
+
+	public static function scopes( $scope ) {
+		return static::$scopes;
+	}
+
+	public static function auth_response( $response ) {
+		return static::$micropub_auth_response;
+	}
+
+	public static function empty_auth_response( $response ) {
+		return array();
+	}
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$author_id     = $factory->user->create(
+			array(
+				'role' => 'author',
+			)
+		);
+		self::$subscriber_id = $factory->user->create(
+			array(
+				'role' => 'subscriber',
+			)
+		);
+	}
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$author_id );
+		remove_filter( 'indieauth_scopes', array( get_called_class(), 'scopes' ) );
+		global $wp_rest_server;
+		$wp_rest_server = null;
+	}
+
+	public function setUp() {
+		global $wp_rest_server;
+		$wp_rest_server = new Spy_REST_Server;
+		do_action( 'rest_api_init', $wp_rest_server );
+		parent::setUp();
+	}
+
+	public function dispatch( $request, $user_id ) {
+		add_filter( 'indieauth_scopes', array( get_called_class(), 'scopes' ), 12 );
+		add_filter( 'indieauth_response', array( get_called_class(), 'auth_response' ), 12 );
+		wp_set_current_user( $user_id );
+		return rest_get_server()->dispatch( $request );
+	}
+
+	public function create_form_request( $POST ) {
+		$request = new WP_REST_Request( 'POST', Micropub_Endpoint::get_micropub_rest_route( true ) );
+		$request->set_header( 'Content-Type', 'application/x-www-form-urlencoded' );
+		$request->set_body_params( $POST );
+		return $request;
+	}
+
+	public function create_json_request( $input ) {
+		$request = new WP_REST_Request( 'POST', Micropub_Endpoint::get_micropub_rest_route( true ) );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( $input ) );
+		return $request;
+	}
+
+	public function insert_post() {
+		return wp_insert_post( static::$wp_args );
+	}
+
+	public function query_request( $GET ) {
+		$request = new WP_REST_Request( 'GET', Micropub_Endpoint::get_micropub_rest_route( true ) );
+		$request->set_query_params( $GET );
+		return $request;
+	}
+
+	public function query_source( $post_id ) {
+		$GET      = array(
+			'q'   => 'source',
+			'url' => 'http://example.org/?p=' . $post_id,
+		);
+		$request  = self::query_request( $GET );
+		$response = Micropub_Endpoint::query_handler( $request );
+		return $response->get_data();
+	}
+
+}

--- a/tests/test_endpoint.php
+++ b/tests/test_endpoint.php
@@ -53,8 +53,8 @@ class Micropub_Endpoint_Test extends Micropub_UnitTestCase {
 
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
-		$this->assertArrayHasKey( Micropub_Endpoint::get_micropub_rest_route( true ), $routes, wp_json_encode( array_keys( $routes ) ) );
-		$this->assertCount( 2, $routes[ Micropub_Endpoint::get_micropub_rest_route(true) ] );
+		$this->assertArrayHasKey( Micropub_Endpoint::get_route( true ), $routes, wp_json_encode( array_keys( $routes ) ) );
+		$this->assertCount( 2, $routes[ Micropub_Endpoint::get_route(true) ] );
 	}
 
 	public function test_parse_geo_uri() {
@@ -63,14 +63,14 @@ class Micropub_Endpoint_Test extends Micropub_UnitTestCase {
 		}
 
 	public function create_form_request( $POST ) {
-		$request = new WP_REST_Request( 'POST', Micropub_Endpoint::get_micropub_rest_route( true ) );
+		$request = new WP_REST_Request( 'POST', Micropub_Endpoint::get_route( true ) );
 		$request->set_header( 'Content-Type', 'application/x-www-form-urlencoded' );
 		$request->set_body_params( $POST );
 		return $request;
 	}
 
 	public function create_json_request( $input ) {
-		$request = new WP_REST_Request( 'POST', Micropub_Endpoint::get_micropub_rest_route( true ) );
+		$request = new WP_REST_Request( 'POST', Micropub_Endpoint::get_route( true ) );
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_body( wp_json_encode( $input ) );
 		return $request;
@@ -81,7 +81,7 @@ class Micropub_Endpoint_Test extends Micropub_UnitTestCase {
 	}
 
 	public function query_request( $GET ) {
-		$request = new WP_REST_Request( 'GET', Micropub_Endpoint::get_micropub_rest_route( true ) );
+		$request = new WP_REST_Request( 'GET', Micropub_Endpoint::get_route( true ) );
 		$request->set_query_params( $GET );
 		return $request;
 	}

--- a/tests/test_media.php
+++ b/tests/test_media.php
@@ -1,42 +1,16 @@
 <?php
 /* Media Endpoint and Upload Tests inspired by REST API Attachment Endpoint */
 
-class Micropub_Media_Test extends WP_UnitTestCase {
+class Micropub_Media_Test extends Micropub_UnitTestCase {
 	
-
-	protected static $author_id;
-	protected static $subscriber_id;
-	protected static $scopes;
-
-	public static function scopes( $scope ) {
-		return static::$scopes;
-	}
-
-	public static function wpSetUpBeforeClass( $factory ) {
-		self::$author_id      = $factory->user->create(
-			array(
-				'role' => 'author',
-			)
-		);
-		self::$subscriber_id      = $factory->user->create(
-			array(
-				'role' => 'subscriber',
-			)
-		);
-
-	}
-	public static function wpTearDownAfterClass() {
-		self::delete_user( self::$author_id );
-		remove_filter( 'indieauth_scopes', array( get_called_class(), 'scopes' ), 12 );
-	}
 	public function setUp() {
-		// parent::setUp();
 		$orig_file       = DIR_MEDIATESTDATA . '/canola.jpg';
 		$this->test_file = '/tmp/canola.jpg';
-		copy( $orig_file, $this->test_file );
-		$orig_file2       = DIR_MEDIATESTDATA . '/codeispoetry.png';
-		$this->test_file2 = '/tmp/codeispoetry.png';
-		copy( $orig_file2, $this->test_file2 );
+	        copy( $orig_file, $this->test_file );
+	        $orig_file2       = DIR_MEDIATESTDATA . '/codeispoetry.png';
+	        $this->test_file2 = '/tmp/codeispoetry.png';
+	        copy( $orig_file2, $this->test_file2 );
+		parent::setUp();
 	}
 
 	public function test_register_routes() {
@@ -73,8 +47,7 @@ class Micropub_Media_Test extends WP_UnitTestCase {
 	}
 
 	public function test_upload_file() {
-		wp_set_current_user( self::$author_id );
-		$response = rest_get_server()->dispatch( self::upload_request() );
+		$response = $this->dispatch( self::upload_request(), self::$author_id );
 		$data     = $response->get_data();
 		$this->assertEquals( 201, $response->get_status(), wp_json_encode( $data ) );
 		// Test that a valid URL is returned in the JSON Body
@@ -87,16 +60,14 @@ class Micropub_Media_Test extends WP_UnitTestCase {
 	}
 
 	public function test_empty_upload() {
-		wp_set_current_user( self::$author_id );
 		$request = new WP_REST_Request( 'POST', Micropub_Media::get_rest_route( true ) );
-		$response = rest_get_server()->dispatch( $request );
+		$response = $this->dispatch( $request, self::$author_id );
 		$data     = $response->get_data();
 		$this->assertEquals( 400, $response->get_status(), wp_json_encode( $data ) );
 	}
 
 	public function test_upload_file_without_scope() {
-		wp_set_current_user( self::$subscriber_id );
-		$response = rest_get_server()->dispatch( self::upload_request() );
+		$response = $this->dispatch( self::upload_request(), self::$subscriber_id );
 		$data     = $response->get_data();
 		$this->assertEquals( 403, $response->get_status(), wp_json_encode( $data ) );
 	}

--- a/tests/test_media.php
+++ b/tests/test_media.php
@@ -15,12 +15,12 @@ class Micropub_Media_Test extends Micropub_UnitTestCase {
 
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
-		$this->assertArrayHasKey( Micropub_Media::get_rest_route( true ), $routes );
-		$this->assertCount( 2, $routes[ Micropub_Media::get_rest_route( true ) ] );
+		$this->assertArrayHasKey( Micropub_Media::get_route( true ), $routes );
+		$this->assertCount( 2, $routes[ Micropub_Media::get_route( true ) ] );
 	}
 
 	public function upload_request() {
-		$request = new WP_REST_Request( 'POST', Micropub_Media::get_rest_route( true ) );
+		$request = new WP_REST_Request( 'POST', Micropub_Media::get_route( true ) );
 		$request->set_header( 'Content-Type', 'image/jpeg' );
 		$request->set_file_params( 
 			array(
@@ -60,7 +60,7 @@ class Micropub_Media_Test extends Micropub_UnitTestCase {
 	}
 
 	public function test_empty_upload() {
-		$request = new WP_REST_Request( 'POST', Micropub_Media::get_rest_route( true ) );
+		$request = new WP_REST_Request( 'POST', Micropub_Media::get_route( true ) );
 		$response = $this->dispatch( $request, self::$author_id );
 		$data     = $response->get_data();
 		$this->assertEquals( 400, $response->get_status(), wp_json_encode( $data ) );


### PR DESCRIPTION
This introduces two new functions so that the apply_filters call in this function is only called in one place in the code. In a future version, plan to use the filter as a fallback and query the IndieAuth plugin directly.

It also fixes some additional testing issues and problems revealed in testing, as well as cleaning up some of the duplicate testing code between the media and micropub endpoints.