### PR TITLE
Do Not Store Built-In Properties

### DIFF
--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -943,7 +943,10 @@ class Micropub_Endpoint extends Micropub_Base {
 				$args['meta_input']['mf2_type'] = $type;
 			}
 			foreach ( $props as $key => $val ) {
-				$args['meta_input'][ 'mf2_' . $key ] = $val;
+				// mp- entries are commands not properties and are therefore not stored.
+				if ( 'mp-' !== substr( $key, 0, 3 ) ) {
+					$args['meta_input'][ 'mf2_' . $key ] = $val;
+				}
 			}
 			return $args;
 		}

--- a/readme.md
+++ b/readme.md
@@ -160,6 +160,10 @@ There are a series of troubleshooting steps in the IndieAuth plugin for this. Th
 
 ## Upgrade Notice
 
+### Version 2.2.3
+
+The Micropub plugin will no longer store published, updated, summary, or name options. These will be derived from the WordPress post properties they are mapped to and returned on query.
+
 ### Version 2.2.0
 
 The Micropub plugin will no longer function without the IndieAuth plugin installed.
@@ -207,12 +211,14 @@ into markdown and saved to readme.md.
 
 ## Changelog
 
-### 2.2.3 (2020-09-08 )
+### 2.2.3 (2020-09-09 )
 
 * Deduplicated endpoint test code from endpoint and media endpoint classes.
 * Removed error suppression revealing several notices that had been hidden. Fixed warning notices.
 * Abstract request for scope and response into functions to avoid calling the actual filter as this may be deprecated in future.
 * Switch check in permissions to whether a user was logged in.
+* Published, updated, name, and summary properties are no longer stored in post meta. When queried, they will be pulled from the equivalent WordPress properties. Content should be as well, however as content in the post includes rendered microformats we need to store the pure version. Might address this in a future version. 
+* As timezone is not stored in the WordPress timestamp, store the timezone offset for the post in meta instead.
 
 ### 2.2.2 (2020-08-23 )
 

--- a/readme.txt
+++ b/readme.txt
@@ -162,6 +162,9 @@ There are a series of troubleshooting steps in the IndieAuth plugin for this. Th
 
 == Upgrade Notice ==
 
+= Version 2.2.3 =
+The Micropub plugin will no longer store published, updated, summary, or name options. These will be derived from the WordPress post properties they are mapped to and returned on query.
+
 = Version 2.2.0 =
 
 The Micropub plugin will no longer function without the IndieAuth plugin installed.
@@ -209,11 +212,13 @@ into markdown and saved to readme.md.
 
 == Changelog ==
 
-= 2.2.3 (2020-09-08 ) =
+= 2.2.3 (2020-09-09 ) =
 * Deduplicated endpoint test code from endpoint and media endpoint classes.
 * Removed error suppression revealing several notices that had been hidden. Fixed warning notices.
 * Abstract request for scope and response into functions to avoid calling the actual filter as this may be deprecated in future.
 * Switch check in permissions to whether a user was logged in.
+* Published, updated, name, and summary properties are no longer stored in post meta. When queried, they will be pulled from the equivalent WordPress properties. Content should be as well, however as content in the post includes rendered microformats we need to store the pure version. Might address this in a future version. 
+* As timezone is not stored in the WordPress timestamp, store the timezone offset for the post in meta instead.
 
 = 2.2.2 (2020-08-23 ) =
 * Fixed and updated testing environment

--- a/tests/test_endpoint.php
+++ b/tests/test_endpoint.php
@@ -130,6 +130,16 @@ class Micropub_Endpoint_Test extends Micropub_UnitTestCase {
 		return $post;
 	}
 
+	// Remove mp properties for comparison.
+	public function remove_mp_properties( $input ) {
+		foreach( $input['properties'] as $key => $value ) {
+			if ( 'mp-' === substr( $key, 0, 3 ) ) {
+				unset( $input['properties'][ $key ] );
+			}
+		}
+		return $input;
+	}
+
 	public function check_create_basic( $request, $input = null ) {
 		if ( ! $input ) {
 			$input = static::$mf2;
@@ -153,6 +163,7 @@ class Micropub_Endpoint_Test extends Micropub_UnitTestCase {
 		$this->assertEquals( '', get_post_meta( $post->ID, 'geo_address', true ) );
 		$source = $this->query_source( $post->ID );
 		$input['properties']['location'] = static::$geo;
+		$input = $this->remove_mp_properties( $input );
 		$this->assertEquals( $input, $source, wp_json_encode( $source ) );
 		return $post;
 	}
@@ -363,7 +374,6 @@ EOF;
 				'type'       => array( 'h-entry' ),
 				'properties' => array(
 					'content'     => array( 'new<br>content' ),
-					'mp-slug'     => array( 'my_slug' ),
 					'name'        => array( 'my name' ),
 					'category'    => array( 'tag1', 'tag4', 'add tag' ),
 					'syndication' => array( 'http://synd/1', 'http://synd/2' ),

--- a/tests/test_endpoint.php
+++ b/tests/test_endpoint.php
@@ -242,9 +242,10 @@ class Micropub_Endpoint_Test extends Micropub_UnitTestCase {
 				),
 			),
 		);
+		$published = current_datetime()->format( DATE_W3C );
 		$post  = self::check_create( self::create_json_request( $input ) );
 		// Add current time as published.
-		$input['properties']['published'] = array( current_datetime()->format( DATE_W3C ) );
+		$input['properties']['published'] = array( $published );
 		$mf2   = $this->query_source( $post->ID );
 		$this->assertEquals( $input, $mf2 );
 	}
@@ -348,6 +349,8 @@ class Micropub_Endpoint_Test extends Micropub_UnitTestCase {
 			'delete'  => array( 'location', 'summary' ),
 		);
 		$response = $this->dispatch( self::create_json_request( $input ), static::$author_id );
+		$updated = current_datetime();
+		$updated = $updated->setTimeZone( new DateTimeZone( '-08:00' ) );
 		$this->check( $response, 200 );
 		$post = get_post( $post_id );
 		// updated
@@ -372,8 +375,6 @@ EOF;
 		// https://github.com/snarfed/wordpress-micropub/issues/16
 		$this->assertEquals( '2016-01-01 12:01:23', $post->post_date );
 		$mf2 = $this->query_source( $post->ID );
-		$updated = current_datetime();
-		$updated = $updated->setTimeZone( new DateTimeZone( '-08:00' ) );
 		$this->assertEquals(
 			array(
 				'type'       => array( 'h-entry' ),
@@ -399,6 +400,7 @@ EOF;
 			'add'    => array( 'category' => array( 'foo', 'bar' ) ),
 		);
 		$response = $this->dispatch( self::create_json_request( $input ), static::$author_id );
+		$published =  current_datetime()->format( DATE_W3C );
 		$this->check( $response, 200 );
 		// added
 		$post = get_post( $post_id );
@@ -412,7 +414,7 @@ EOF;
 				'properties' => array(
 					'content'  => array( 'my<br>content' ),
 					'category' => array( 'foo', 'bar' ),
-					'published' => array( current_datetime()->format( DATE_W3C ) )
+					'published' => array( $published )
 				),
 			),
 			$mf2
@@ -633,9 +635,10 @@ EOF;
 				'content' => array( 'Charles ☕ Foo covers 😻 #dougbeal.com' ),
 			),
 		);
+		$published = current_datetime()->format( DATE_W3C );
 		$post  = self::check_create( self::create_json_request( $input ) );
 		$mf2   = $this->query_source( $post->ID );
-		$input['properties']['published'] = array( current_datetime()->format( DATE_W3C ) );
+		$input['properties']['published'] = array( $published );
 
 		$this->assertEquals( $input, $mf2 );
 	}


### PR DESCRIPTION
This PR eliminates the storage of all mp- passed as these are commands, not properties.  It also stops storing published, updated, summary, and name as these are now solely stored in the WordPress post. To accommodate the fact that there is no timezone offset in WordPress, this is stored.