### PR TITLE
Add publish date to media return

### DIFF
--- a/includes/class-micropub-media.php
+++ b/includes/class-micropub-media.php
@@ -230,8 +230,12 @@ class Micropub_Media extends Micropub_Base {
 	 * Returns information about an attachment
 	 */
 	private static function return_media_data( $attachment_id ) {
-		$data        = wp_get_attachment_metadata( $attachment_id );
-		$data['url'] = wp_get_attachment_image_url( $attachment_id, 'full' );
+		$data              = wp_get_attachment_metadata( $attachment_id );
+		$data['url']       = wp_get_attachment_image_url( $attachment_id, 'full' );
+		$datetime          = get_post_datetime( $attachment_id );
+		$data['published'] = $datetime->format( DATE_W3C );
+		$datetime          = get_post_datetime( $attachment_id, 'modified' );
+		$data['updated']   = $datetime->format( DATE_W3C );
 		return $data;
 	}
 
@@ -296,10 +300,9 @@ class Micropub_Media extends Micropub_Base {
 					);
 					if ( is_array( $attachments ) ) {
 						foreach ( $attachments as $attachment ) {
+							$datetime = get_post_datetime( $attachment );
 							if ( wp_attachment_is( 'image', $attachment ) ) {
-								return array(
-									'url' => wp_get_attachment_image_url( $attachment, 'full' ),
-								);
+								return self::return_media_data( $attachment );
 							}
 						}
 					}

--- a/micropub.php
+++ b/micropub.php
@@ -7,7 +7,7 @@
  * Author: IndieWeb WordPress Outreach Club
  * Author URI: https://indieweb.org/WordPress_Outreach_Club
  * Text Domain: micropub
- * Version: 2.2.3
+ * Version: 2.2.4
  */
 
 /* See README for supported filters and actions.

--- a/readme.md
+++ b/readme.md
@@ -207,6 +207,14 @@ into markdown and saved to readme.md.
 
 ## Changelog
 
+### 2.2.4 (2021-05-06 )
+
+* Add published date to return from q
+
+### source on media endpoint
+
+
+
 ### 2.2.3 (2020-09-09 )
 
 * Deduplicated endpoint test code from endpoint and media endpoint classes.

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: indieweb, snarfed, dshanske
 Tags: micropub, publish, indieweb, microformats
 Requires at least: 4.9.9
 Requires PHP: 5.6
-Tested up to: 5.5.1
-Stable tag: 2.2.3
+Tested up to: 5.7
+Stable tag: 2.2.4
 License: CC0
 License URI: http://creativecommons.org/publicdomain/zero/1.0/
 Donate link: -
@@ -209,6 +209,9 @@ To automatically convert the readme.txt file to readme.md, you may, if you have 
 into markdown and saved to readme.md.
 
 == Changelog ==
+
+= 2.2.4 (2021-05-06 ) =
+* Add published date to return from q=source on media endpoint
 
 = 2.2.3 (2020-09-09 ) =
 * Deduplicated endpoint test code from endpoint and media endpoint classes.


### PR DESCRIPTION
This adds the published date to the media query return. Quill uses this.