### PR TITLE
Uploaded URLs filenames wont include query strings

### DIFF
--- a/includes/class-micropub-media.php
+++ b/includes/class-micropub-media.php
@@ -142,7 +142,7 @@ class Micropub_Media extends Micropub_Base {
 			return new WP_Micropub_Error( 'invalid_request', $tmp->get_message(), 400 );
 		}
 		$file_array = array(
-			'name'     => basename( $url ),
+			'name'     => basename( parse_url($url)['path'] ),
 			'tmp_name' => $tmp,
 			'error'    => 0,
 			'size'     => filesize( $tmp ),

--- a/includes/class-micropub-media.php
+++ b/includes/class-micropub-media.php
@@ -142,7 +142,7 @@ class Micropub_Media extends Micropub_Base {
 			return new WP_Micropub_Error( 'invalid_request', $tmp->get_message(), 400 );
 		}
 		$file_array = array(
-			'name'     => basename( parse_url($url)['path'] ),
+			'name'     => basename( wp_parse_url( $url, PHP_URL_PATH ) ),
 			'tmp_name' => $tmp,
 			'error'    => 0,
 			'size'     => filesize( $tmp ),


### PR DESCRIPTION
Ensures that when sent a URL with query strings (like instagram) the filename saved doesnt include the query string.