### PR TITLE
Add more comprehensive tests for post status determination

### DIFF
--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -646,7 +646,10 @@ class Micropub_Endpoint extends Micropub_Base {
 			}
 			return 'draft';
 		}
-		// Execution will never reach here
+
+		// If visibility is public and no post-status is specified,
+		// return the default post status value.
+		return self::default_post_status();
 	}
 
 	/**

--- a/tests/test_endpoint-post-status.php
+++ b/tests/test_endpoint-post-status.php
@@ -1,0 +1,103 @@
+<?php
+
+class Micropub_Endpoint_Post_Status_Test extends Micropub_UnitTestCase {
+	/**
+	 * An instance of the Micropub_Endpoint class.
+	 *
+	 * @var \Micropub_Endpoint
+	 */
+	private $endpoint;
+
+	/**
+	 * An instance of the private post_status method from
+	 * the Micropub_Endpoint class.
+	 */
+	private $method;
+
+	public function setUp() {
+		$this->endpoint = new Micropub_Endpoint();
+
+		// Perform magic to access the private method for testing.
+		$ref = new ReflectionClass( 'Micropub_Endpoint' );
+		$this->method = $ref->getMethod( 'post_status' );
+		$this->method->setAccessible( true );
+	}
+
+	/**
+	 * Provide possible conditions with which to test the Micropub_Endpoint's
+	 * post_status method.
+	 *
+	 * @return array A list of conditions.
+	 */
+	public function data_get_conditions() {
+		return array(
+			array(
+				'publish',
+				array( 'properties' => array() ),
+				'The default post status of publish should be used if post-status and visibility are not provided.'
+			),
+			array(
+				'publish',
+				array( 'properties' => array( 'post-status' => array( 'published' ) ) )
+			),
+			array(
+				'draft',
+				array( 'properties' => array( 'post-status' => array( 'draft' ) ) )
+			),
+			array(
+				null,
+				array( 'properties' => array( 'post-status' => array( 'invalid' ) ) )
+			),
+			array(
+				'private',
+				array( 'properties' => array( 'visibility' => array( 'private' ) ) )
+			),
+			array(
+				'publish',
+				array( 'properties' => array( 'visibility' => array( 'public' ) ) ),
+				'Public visibility with no specific post-status property should return the default post status.'
+			),
+			array(
+				null,
+				array( 'properties' => array( 'visibility' => array( 'invalid' ) ) ),
+				'A null value should be returned when visibility is invalid.'
+			),
+			array(
+				null,
+				array( 'properties' => array( 'visibility' => array( 'invalid' ), 'post-status' => array( 'published' ) ) ),
+				'A null value should be returned when visibility is invalid, even if post-status is valid.'
+			),
+			array(
+				'publish',
+				array( 'properties' => array( 'visibility' => array( 'public' ), 'post-status' => array( 'published' ) ) )
+			),
+			array(
+				'draft',
+				array( 'properties' => array( 'visibility' => array( 'public' ), 'post-status' => array( 'draft' ) ) )
+			),
+			array(
+				'private',
+				array( 'properties' => array( 'visibility' => array( 'private' ), 'post-status' => array( 'publish' ) ) )
+			),
+		);
+	}
+
+	/**
+	 * If neither post_status or visibility are assigned, the default
+	 * post status should be used.
+	 *
+	 * @dataProvider data_get_conditions
+	 *
+	 * @param string|null A post status string if valid, null if not.
+	 * @param array       A list of arguments to pass to post_status().
+	 * @param string      A specific error message, if available.
+	 */
+	public function test_post_status_default( $expected, $args, $error = '' ) {
+		$result = $this->method->invokeArgs(
+			$this->endpoint,
+			array( $args )
+		);
+
+		$this->assertEquals( $expected, $result, $error );
+	}
+}


### PR DESCRIPTION
This introduces test coverage for what I believe to be the possible combinations for the `visibility` and `post-status` properties when `Micropub_Endpoint::post_status()` is used to set post status.

The tests flagged an issue where if `visibility` is set to `public` and there is no `post-status` property, then `null` would be returned an an error generated. It seems safe to assume a default post status when `visibility` is set to `public`, so I added another commit to help tests pass.

I originally looked into this issue and thought (🤦🏻) the issue was a string/array mix up. After digging further, I see now that this plugin requires an array value for both `visibility` and `post-status` even though the spec seems to imply a string. Other portions of the plugin check for a numeric array in addition to the string. This seems like something that could be done here, but I wanted to check before going any further. 