### PR TITLE
Only Stores the Client Related Keys and the UUID in Micropub Auth Response

### DIFF
--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -972,7 +972,7 @@ class Micropub_Endpoint extends Micropub_Base {
 		$micropub_auth_response = static::$micropub_auth_response;
 		if ( $micropub_auth_response || ( is_assoc_array( $micropub_auth_response ) ) ) {
 			$args['meta_input']                           = mp_get( $args, 'meta_input' );
-			$args['meta_input']['micropub_auth_response'] = $micropub_auth_response;
+			$args['meta_input']['micropub_auth_response'] = wp_slice_assoc_array( $micropub_auth_response, array( 'client_id', 'client_name', 'client_icon', 'uuid' ) );
 		}
 		return $args;
 	}

--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -972,7 +972,7 @@ class Micropub_Endpoint extends Micropub_Base {
 		$micropub_auth_response = static::$micropub_auth_response;
 		if ( $micropub_auth_response || ( is_assoc_array( $micropub_auth_response ) ) ) {
 			$args['meta_input']                           = mp_get( $args, 'meta_input' );
-			$args['meta_input']['micropub_auth_response'] = wp_slice_assoc_array( $micropub_auth_response, array( 'client_id', 'client_name', 'client_icon', 'uuid' ) );
+			$args['meta_input']['micropub_auth_response'] = wp_array_slice_assoc( $micropub_auth_response, array( 'client_id', 'client_name', 'client_icon', 'uuid' ) );
 		}
 		return $args;
 	}


### PR DESCRIPTION
There is no need to store all the other properties around the token. This only does the client_id, client_name, client_icon, and uuid going forward. 