### PR TITLE
Fix #278

### DIFF
--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -716,7 +716,7 @@ class Micropub_Endpoint extends Micropub_Base {
 			}
 		}
 		if ( isset( $args['post_name'] ) ) {
-			$args['post_name'] = sanitize_title( $args['post_name'] );
+			$args['post_name'] = sanitize_title( ( (array) $args['post_name'] )[0] );
 		}
 
 		if ( isset( $props['published'] ) ) {


### PR DESCRIPTION
`sanitize_title()` expects a string, but `$args['post_name']` is, or can be, an array. This change addresses that.