### PR TITLE
Stop including visible text in reply contexts

### DIFF
--- a/includes/class-micropub-render.php
+++ b/includes/class-micropub-render.php
@@ -47,13 +47,24 @@ class Micropub_Render {
 					$val['name'] = $val['url'];
 				}
 				if ( isset( $val['url'] ) ) {
-					$lines[] = sprintf(
-						'<p>%1s <a class="u-%2s" href="%3s">%4s</a>.</p>',
-						$verbs[ $prop ],
-						$prop,
-						$val['url'],
-						$val['name']
-					);
+					if ( $prop == 'in-reply-to' && ! isset( $props['rsvp']) ) {
+						// Special case replies. Don't include any visible text,
+						// since it goes inside e-content, which webmention
+						// recipients use as the reply text.
+						$lines[] = sprintf(
+							'<a class="u-%1s" href="%2s"></a>',
+							$prop,
+							$val['url']
+						);
+					} else {
+						$lines[] = sprintf(
+							'<p>%1s <a class="u-%2s" href="%3s">%4s</a>.</p>',
+							$verbs[ $prop ],
+							$prop,
+							$val['url'],
+							$val['name']
+						);
+					}
 				}
 			}
 		}

--- a/readme.md
+++ b/readme.md
@@ -209,16 +209,20 @@ into markdown and saved to readme.md.
 
 ## Changelog
 
-### 2.3.2 (2022-06-22 )
+### 2.3.3 (unreleased)
+
+* Stop including visible text in reply contexts since they go inside since they go inside e-content, which webmention recipients use as the reply text.
+
+### 2.3.2 (2022-06-22)
 
 * Update readme
 * Fix client name bug
 
-### 2.3.1 (2021-12-25 )
+### 2.3.1 (2021-12-25)
 
 * Made one little mistake.
 
-### 2.3.0 (2021-12-25 )
+### 2.3.0 (2021-12-25)
 
 * Sanitize media endpoint queries
 * Add mime_type filter for media queries
@@ -229,7 +233,7 @@ into markdown and saved to readme.md.
 * Add support for Visibility config return https://github.com/indieweb/micropub-extensions/issues/8#issuecomment-536301952
 * Sets `_edit_last` property when a post is updated.
 
-### 2.2.5 (2021-09-22 )
+### 2.2.5 (2021-09-22)
 
 * Update readme links
 * Add filter to allow custom database insert.
@@ -239,11 +243,11 @@ into markdown and saved to readme.md.
 * New query unit test revealed bug in new q=source&url= query previously introduced.
 * Update media response to now just include published, updated, created, and mime_type for now.
 
-### 2.2.4 (2021-05-06 )
+### 2.2.4 (2021-05-06)
 
 * Add published date to return from q=source on media endpoint
 
-### 2.2.3 (2020-09-09 )
+### 2.2.3 (2020-09-09)
 
 * Deduplicated endpoint test code from endpoint and media endpoint classes.
 * Removed error suppression revealing several notices that had been hidden. Fixed warning notices.
@@ -253,24 +257,24 @@ into markdown and saved to readme.md.
 * As timezone is not stored in the WordPress timestamp, store the timezone offset for the post in meta instead.
 * Sideload and set featured images if featured property is set.
 
-### 2.2.2 (2020-08-23 )
+### 2.2.2 (2020-08-23)
 
 * Fixed and updated testing environment
 * Fixed failing tests as a result of update to testing environment
 * Change return response code based on spec update from 401 to 403
 
-### 2.2.1 (2020-07-31 )
+### 2.2.1 (2020-07-31)
 
 * Change category query parameter from search to filter per decision at Micropub Popup Session
 * Fix permissions for Media Endpoint to match Endpoint
 * For source query on both media and micropub endpoint support offset parameter
 
-### 2.2.0 (2020-07-25 )
+### 2.2.0 (2020-07-25)
 
 * Deprecate MICROPUB_LOCAL_AUTH, MICROPUB_AUTHENTICATION_ENDPOINT and MICROPUB_TOKEN_ENDPOINT constants.
 * Remove IndieAuth Client code, will now require the IndieAuth or other plugin that does not yet exist.
 
-### 2.1.0 (2020-02-06 )
+### 2.1.0 (2020-02-06)
 
 * Fix bug where timezone meta key was always set to website timezone instead of provided one
 * Fix issue where title and caption were not being set for images by adopting code from WordPress core

--- a/tests/test_render.php
+++ b/tests/test_render.php
@@ -55,9 +55,9 @@ class MicropubRenderTest extends WP_UnitTestCase {
 	}
 
 	function test_create_reply() {
-		$input = $this->create_interaction( 'in-reply-to' ); 
+		$input = $this->create_interaction( 'in-reply-to' );
 		$post_content = Micropub_Render::generate_post_content( '', $input );
-		$this->assertEquals( '<p>In reply to <a class="u-in-reply-to" href="http://target">http://target</a>.</p>', $post_content );
+		$this->assertEquals( '<a class="u-in-reply-to" href="http://target"></a>', $post_content );
 
 	}
 
@@ -170,14 +170,14 @@ EOF
 	function test_merges_auto_generated_content() {
 		$input = array(
 			'type' => array( 'h-entry' ),
-			'properties' => array( 
+			'properties' => array(
 				'content' => array( 'foo bar' ),
-				'in-reply-to' => array( 'http://target' )
+				'repost-of' => array( 'http://target' )
 			)
 		);
 		$post_content = Micropub_Render::generate_post_content( 'foo bar', $input );
 		$this->assertEquals( <<<EOF
-<p>In reply to <a class="u-in-reply-to" href="http://target">http://target</a>.</p>
+<p>Reposted <a class="u-repost-of" href="http://target">http://target</a>.</p>
 <div class="e-content">
 foo bar
 </div>


### PR DESCRIPTION
...since they go inside since they go inside e-content, which webmention recipients use as the reply text.

https://chat.indieweb.org/wordpress/2023-02-27#t1677522099115700