### PR TITLE
Dynamic Rendering

### DIFF
--- a/includes/class-micropub-base.php
+++ b/includes/class-micropub-base.php
@@ -128,7 +128,7 @@ abstract class Micropub_Base {
 	/**
 	 * Returns the mf2 properties for a post.
 	 */
-	public static function get_mf2( $post_id ) {
+	public static function get_mf2( $post_id = null ) {
 		$mf2  = array();
 		$post = get_post( $post_id );
 

--- a/includes/class-micropub-base.php
+++ b/includes/class-micropub-base.php
@@ -124,4 +124,39 @@ abstract class Micropub_Base {
 		}
 		return $result;
 	}
+
+	/**
+	 * Returns the mf2 properties for a post.
+	 */
+	public static function get_mf2( $post_id ) {
+		$mf2  = array();
+		$post = get_post( $post_id );
+
+		foreach ( get_post_meta( $post_id ) as $field => $val ) {
+			$val = maybe_unserialize( $val[0] );
+			if ( 'mf2_type' === $field ) {
+				$mf2['type'] = $val;
+			} elseif ( 'mf2_' === substr( $field, 0, 4 ) ) {
+				$mf2['properties'][ substr( $field, 4 ) ] = $val;
+			}
+		}
+
+		// Time Information
+		$published                      = micropub_get_post_datetime( $post );
+		$updated                        = micropub_get_post_datetime( $post, 'modified' );
+		$mf2['properties']['published'] = array( $published->format( DATE_W3C ) );
+		if ( $published->getTimestamp() !== $updated->getTimestamp() ) {
+			$mf2['properties']['updated'] = array( $updated->format( DATE_W3C ) );
+		}
+
+		if ( ! empty( $post->post_title ) ) {
+			$mf2['properties']['name'] = array( $post->post_title );
+		}
+
+		if ( ! empty( $post->post_excerpt ) ) {
+			$mf2['properties']['summary'] = array( $post->post_excerpt );
+		}
+
+		return $mf2;
+	}
 }

--- a/includes/class-micropub-base.php
+++ b/includes/class-micropub-base.php
@@ -49,12 +49,12 @@ abstract class Micropub_Base {
 	/**
 	 * Generates webfinger/host-meta links
 	 */
-	public static function jrd_links( $array ) {
-		$array['links'][] = array(
+	public static function jrd_links( $links ) {
+		$links['links'][] = array(
 			'rel'  => static::get_rel(),
 			'href' => static::get_endpoint(),
 		);
-		return $array;
+		return $links;
 	}
 
 
@@ -79,11 +79,11 @@ abstract class Micropub_Base {
 		return error_log( sprintf( '%1$s: %2$s', $name, $message ) ); // phpcs:ignore
 	}
 
-	public static function get( $array, $key, $default = array() ) {
-		if ( is_array( $array ) ) {
-			return isset( $array[ $key ] ) ? $array[ $key ] : $default;
+	public static function get( $a, $key, $args = array() ) {
+		if ( is_array( $a ) ) {
+			return isset( $a[ $key ] ) ? $a[ $key ] : $args;
 		}
-		return $default;
+		return $args;
 	}
 
 	public static function load_auth() {
@@ -154,7 +154,10 @@ abstract class Micropub_Base {
 		}
 
 		if ( ! empty( $post->post_excerpt ) ) {
-			$mf2['properties']['summary'] = array( $post->post_excerpt );
+			$mf2['properties']['summary'] = array( htmlspecialchars_decode( $post->post_excerpt ) );
+		}
+		if ( ! array_key_exists( 'content', $mf2['properties'] ) && ! empty( $post->post_content ) ) {
+			$mf2['properties']['content'] = array( htmlspecialchars_decode( $post->post_content ) );
 		}
 
 		return $mf2;

--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -988,6 +988,7 @@ class Micropub_Endpoint extends Micropub_Base {
 		if ( $micropub_auth_response || ( is_assoc_array( $micropub_auth_response ) ) ) {
 			$args['meta_input']                           = mp_get( $args, 'meta_input' );
 			$args['meta_input']['micropub_auth_response'] = wp_array_slice_assoc( $micropub_auth_response, array( 'client_id', 'client_name', 'client_icon', 'uuid' ) );
+			$args['meta_input']['micropub_auth_response']['version'] = micropub_get_plugin_version();
 		}
 		return $args;
 	}

--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -1073,41 +1073,6 @@ class Micropub_Endpoint extends Micropub_Base {
 		return $args;
 	}
 
-	/**
-	 * Returns the mf2 properties for a post.
-	 */
-	public static function get_mf2( $post_id ) {
-		$mf2  = array();
-		$post = get_post( $post_id );
-
-		foreach ( get_post_meta( $post_id ) as $field => $val ) {
-			$val = maybe_unserialize( $val[0] );
-			if ( 'mf2_type' === $field ) {
-				$mf2['type'] = $val;
-			} elseif ( 'mf2_' === substr( $field, 0, 4 ) ) {
-				$mf2['properties'][ substr( $field, 4 ) ] = $val;
-			}
-		}
-
-		// Time Information
-		$published                      = micropub_get_post_datetime( $post );
-		$updated                        = micropub_get_post_datetime( $post, 'modified' );
-		$mf2['properties']['published'] = array( $published->format( DATE_W3C ) );
-		if ( $published->getTimestamp() !== $updated->getTimestamp() ) {
-			$mf2['properties']['updated'] = array( $updated->format( DATE_W3C ) );
-		}
-
-		if ( ! empty( $post->post_title ) ) {
-			$mf2['properties']['name'] = array( $post->post_title );
-		}
-
-		if ( ! empty( $post->post_excerpt ) ) {
-			$mf2['properties']['summary'] = array( $post->post_excerpt );
-		}
-
-		return $mf2;
-	}
-
 	/* Takes form encoded input and converts to json encoded input */
 	public static function form_to_json( $data ) {
 		$input = array();

--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -1003,8 +1003,7 @@ class Micropub_Endpoint extends Micropub_Base {
 	 */
 	public static function store_mf2( $args ) {
 		// Properties that map to WordPress properties.
-		// TODO: We need to still store content because the plugin adds markup to the content stored.
-		$excludes = array( 'name', 'published', 'updated', 'summary', 'updated' );
+		$excludes = array( 'name', 'published', 'updated', 'summary', 'updated', 'content', 'visibility' );
 		$props    = mp_get( static::$input, 'properties', false );
 		if ( ! isset( $args['ID'] ) && $props ) {
 			$args['meta_input'] = mp_get( $args, 'meta_input' );

--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -988,7 +988,7 @@ class Micropub_Endpoint extends Micropub_Base {
 		if ( $micropub_auth_response || ( is_assoc_array( $micropub_auth_response ) ) ) {
 			$args['meta_input']                           = mp_get( $args, 'meta_input' );
 			$args['meta_input']['micropub_auth_response'] = wp_array_slice_assoc( $micropub_auth_response, array( 'client_id', 'client_name', 'client_icon', 'uuid' ) );
-			$args['meta_input']['micropub_auth_response']['version'] = micropub_get_plugin_version();
+			$args['meta_input']['micropub_version']['version'] = micropub_get_plugin_version();
 		}
 		return $args;
 	}

--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -41,7 +41,7 @@ class Micropub_Endpoint extends Micropub_Base {
 		if ( is_array( $a ) ) {
 			return isset( $a[ $key ] ) ? $a[ $key ] : $d;
 		}
-		return $default;
+		return $d;
 	}
 
 	public static function register_route() {

--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -1004,7 +1004,7 @@ class Micropub_Endpoint extends Micropub_Base {
 	 */
 	public static function store_mf2( $args ) {
 		// Properties that map to WordPress properties.
-		$excludes = array( 'name', 'published', 'updated', 'summary', 'updated', 'content', 'visibility' );
+		$excludes = array( 'name', 'published', 'updated', 'summary', 'content', 'visibility' );
 		$props    = mp_get( static::$input, 'properties', false );
 		if ( ! isset( $args['ID'] ) && $props ) {
 			$args['meta_input'] = mp_get( $args, 'meta_input' );

--- a/includes/class-micropub-endpoint.php
+++ b/includes/class-micropub-endpoint.php
@@ -37,9 +37,9 @@ class Micropub_Endpoint extends Micropub_Base {
 		add_filter( 'rest_request_after_callbacks', array( static::class, 'return_micropub_error' ), 10, 3 );
 	}
 
-	public static function get( $array, $key, $default = array() ) {
-		if ( is_array( $array ) ) {
-			return isset( $array[ $key ] ) ? $array[ $key ] : $default;
+	public static function get( $a, $key, $d = array() ) {
+		if ( is_array( $a ) ) {
+			return isset( $a[ $key ] ) ? $a[ $key ] : $d;
 		}
 		return $default;
 	}
@@ -986,8 +986,8 @@ class Micropub_Endpoint extends Micropub_Base {
 	public static function store_micropub_auth_response( $args ) {
 		$micropub_auth_response = static::$micropub_auth_response;
 		if ( $micropub_auth_response || ( is_assoc_array( $micropub_auth_response ) ) ) {
-			$args['meta_input']                           = mp_get( $args, 'meta_input' );
-			$args['meta_input']['micropub_auth_response'] = wp_array_slice_assoc( $micropub_auth_response, array( 'client_id', 'client_name', 'client_icon', 'uuid' ) );
+			$args['meta_input']                                = mp_get( $args, 'meta_input' );
+			$args['meta_input']['micropub_auth_response']      = wp_array_slice_assoc( $micropub_auth_response, array( 'client_id', 'client_name', 'client_icon', 'uuid' ) );
 			$args['meta_input']['micropub_version']['version'] = micropub_get_plugin_version();
 		}
 		return $args;

--- a/includes/class-micropub-error.php
+++ b/includes/class-micropub-error.php
@@ -16,9 +16,9 @@ class WP_Micropub_Error extends WP_REST_Response {
 		}
 	}
 
-	public function set_debug( $array ) {
+	public function set_debug( $a ) {
 		$data = $this->get_data();
-		$this->set_data( array_merge( $data, $array ) );
+		$this->set_data( array_merge( $data, $a ) );
 	}
 
 	public function to_wp_error() {

--- a/includes/class-micropub-render.php
+++ b/includes/class-micropub-render.php
@@ -30,11 +30,21 @@ class Micropub_Render {
 	}
 
 	public static function should_dynamic_render( $post = null ) {
-		$post    = get_post();
-		$content = get_post_meta( $post->ID, 'mf2_content', true );
-		$should  = $content ? false : true;
+		$post = get_post();
 		if ( class_exists( 'Post_Kinds_Plugin' ) ) {
 			$should = false;
+		} else {
+			$response = get_post_meta( $post->ID, 'micropub_auth_response', true );
+			if ( ! $response ) {
+				$should = false;
+			}
+			if ( is_array( $response ) && array_key_exists( 'version', $response ) ) {
+				$should = true;
+			} elseif ( get_post_meta( $post->ID, 'mf2_content', true ) ) {
+				$should = false;
+			} else {
+				$should = true;
+			}
 		}
 		return apply_filters( 'micropub_dynamic_render', $should, $post );
 	}

--- a/includes/class-micropub-render.php
+++ b/includes/class-micropub-render.php
@@ -34,12 +34,9 @@ class Micropub_Render {
 		if ( class_exists( 'Post_Kinds_Plugin' ) ) {
 			$should = false;
 		} else {
-			$response = get_post_meta( $post->ID, 'micropub_auth_response', true );
-			if ( ! $response ) {
+			$version = get_post_meta( $post->ID, 'micropub_version', true );
+			if ( ! $version ) {
 				$should = false;
-			}
-			if ( is_array( $response ) && array_key_exists( 'version', $response ) ) {
-				$should = true;
 			} elseif ( get_post_meta( $post->ID, 'mf2_content', true ) ) {
 				$should = false;
 			} else {

--- a/includes/compat-functions.php
+++ b/includes/compat-functions.php
@@ -93,10 +93,10 @@ if ( ! function_exists( 'array_key_first' ) ) {
 
 // Polyfill for pre-PHP 7.3.
 if ( ! function_exists( 'array_key_last' ) ) {
-	function array_key_last( $array ) {
-		if ( ! is_array( $array ) || empty( $array ) ) {
+	function array_key_last( $a ) {
+		if ( ! is_array( $a ) || empty( $a ) ) {
 			return null;
 		}
-		return array_keys( $array )[ count( $array ) - 1 ];
+		return array_keys( $a )[ count( $a ) - 1 ];
 	}
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,7 +1,7 @@
 <?php
 
-function is_assoc_array( $array ) {
-	return is_array( $array ) && array_values( $array ) !== $array;
+function is_assoc_array( $assoc ) {
+	return is_array( $assoc ) && array_values( $assoc ) !== $assoc;
 }
 
 
@@ -23,10 +23,10 @@ if ( ! function_exists( 'getallheaders' ) ) {
 }
 
 if ( ! function_exists( 'mp_get' ) ) {
-	function mp_get( $array, $key, $default = array(), $index = false ) {
-		$return = $default;
-		if ( is_array( $array ) && isset( $array[ $key ] ) ) {
-			$return = $array[ $key ];
+	function mp_get( $data, $key, $def = array(), $index = false ) {
+		$return = $def;
+		if ( is_array( $data ) && isset( $data[ $key ] ) ) {
+			$return = $data[ $key ];
 		}
 		if ( $index && wp_is_numeric_array( $return ) && ! empty( $return ) ) {
 			$return = $return[0];
@@ -37,10 +37,10 @@ if ( ! function_exists( 'mp_get' ) ) {
 
 if ( ! function_exists( 'mp_filter' ) ) {
 	// Searches for partial matches in an array of strings
-	function mp_filter( $array, $filter ) {
+	function mp_filter( $a, $filter ) {
 		return array_values(
 			array_filter(
-				$array,
+				$a,
 				function ( $value ) use ( $filter ) {
 					return ( false !== stripos( $value, $filter ) );
 				}
@@ -60,6 +60,10 @@ if ( ! function_exists( 'is_micropub_post' ) ) {
 		$post = get_post( $post );
 		if ( ! $post ) {
 			return false;
+		}
+		$response = get_post_meta( $post->ID, 'micropub_version', true );
+		if ( $response ) {
+			return true;
 		}
 		$response = get_post_meta( $post->ID, 'micropub_auth_response', true );
 		if ( ! $response ) {

--- a/micropub.php
+++ b/micropub.php
@@ -77,6 +77,9 @@ function micropub_not_ssl_notice() {
 }
 add_action( 'admin_notices', 'micropub_not_ssl_notice' );
 
+function micropub_get_plugin_version() {
+	return get_file_data( __FILE__, array( 'Version' => 'Version' ) )['Version'];
+}
 
 function micropub_indieauth_not_installed_notice() {
 	?>

--- a/micropub.php
+++ b/micropub.php
@@ -12,7 +12,7 @@
  * Text Domain: micropub
  * License: CC0
  * License URI: http://creativecommons.org/publicdomain/zero/1.0/
- * Version: 2.3.3
+ * Version: 2.4.0
  */
 
 /* See README for supported filters and actions.

--- a/readme.md
+++ b/readme.md
@@ -2,8 +2,8 @@
 **Contributors:** [indieweb](https://profiles.wordpress.org/indieweb/), [snarfed](https://profiles.wordpress.org/snarfed/), [dshanske](https://profiles.wordpress.org/dshanske/)  
 **Tags:** micropub, publish, indieweb, microformats  
 **Requires at least:** 4.9.9  
-**Tested up to:** 6.5  
-**Stable tag:** 2.3.3  
+**Tested up to:** 6.5.2  
+**Stable tag:** 2.4.0  
 **Requires PHP:** 7.2  
 **License:** CC0  
 **License URI:** http://creativecommons.org/publicdomain/zero/1.0/  
@@ -174,7 +174,7 @@ the entire settings page was removed.
 
 The older MICROPUB_DRAFT_MODE config override remains in place for now.
 
-Static rendering for newer posts has been replaced by dynamic render. This means that if you disable this plugin, it will not render the microformats. For version 2.4.1 this is using the same code used for static 
+Static rendering for newer posts has been replaced by dynamic render. This means that if you disable this plugin, it will not render the microformats on newer posts. This is using the same code used for static 
 rendering but future enhancements are planned.
 
 ### Version 2.2.3 ###
@@ -227,11 +227,11 @@ into markdown and saved to readme.md.
 
 ## Changelog ##
 
-### 2.4.0 (202x-xx-xx) ###
+### 2.4.0 (2024-xx-xx) ###
 * Remove sole setting as no longer needed(see upgrade notice)
 * Remove settings page as no more settings.
 * Bump minimum PHP version to PHP7.2
-* Require IndieAuth plugin
+* Require IndieAuth plugin as a dependency
 * Switch to dynamic from static rendering on posts...markup will no longer be placed inside the content block but dynamically added.
 
 ### 2.3.3 (2023-03-10) ###

--- a/readme.md
+++ b/readme.md
@@ -174,6 +174,9 @@ the entire settings page was removed.
 
 The older MICROPUB_DRAFT_MODE config override remains in place for now.
 
+Static rendering for newer posts has been replaced by dynamic render. This means that if you disable this plugin, it will not render the microformats. For version 2.4.1 this is using the same code used for static 
+rendering but future enhancements are planned.
+
 ### Version 2.2.3 ###
 The Micropub plugin will no longer store published, updated, summary, or name options. These will be derived from the WordPress post properties they are mapped to and returned on query.
 
@@ -229,6 +232,7 @@ into markdown and saved to readme.md.
 * Remove settings page as no more settings.
 * Bump minimum PHP version to PHP7.2
 * Require IndieAuth plugin
+* Switch to dynamic from static rendering on posts...markup will no longer be placed inside the content block but dynamically added.
 
 ### 2.3.3 (2023-03-10) ###
 * Stop including visible text in reply contexts since they go inside since they go inside e-content, which webmention recipients use as the reply text.

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: indieweb, snarfed, dshanske
 Tags: micropub, publish, indieweb, microformats
 Requires at least: 4.9.9
-Tested up to: 6.5
-Stable tag: 2.3.3
+Tested up to: 6.5.2
+Stable tag: 2.4.0
 Requires PHP: 7.2
 License: CC0
 License URI: http://creativecommons.org/publicdomain/zero/1.0/
@@ -174,7 +174,7 @@ the entire settings page was removed.
 
 The older MICROPUB_DRAFT_MODE config override remains in place for now.
 
-Static rendering for newer posts has been replaced by dynamic render. This means that if you disable this plugin, it will not render the microformats. For version 2.4.1 this is using the same code used for static 
+Static rendering for newer posts has been replaced by dynamic render. This means that if you disable this plugin, it will not render the microformats on newer posts. This is using the same code used for static 
 rendering but future enhancements are planned.
 
 = Version 2.2.3 =
@@ -227,11 +227,11 @@ into markdown and saved to readme.md.
 
 == Changelog ==
 
-= 2.4.0 (202x-xx-xx) =
+= 2.4.0 (2024-xx-xx) =
 * Remove sole setting as no longer needed(see upgrade notice)
 * Remove settings page as no more settings.
 * Bump minimum PHP version to PHP7.2
-* Require IndieAuth plugin
+* Require IndieAuth plugin as a dependency
 * Switch to dynamic from static rendering on posts...markup will no longer be placed inside the content block but dynamically added.
 
 = 2.3.3 (2023-03-10) =

--- a/readme.txt
+++ b/readme.txt
@@ -174,6 +174,9 @@ the entire settings page was removed.
 
 The older MICROPUB_DRAFT_MODE config override remains in place for now.
 
+Static rendering for newer posts has been replaced by dynamic render. This means that if you disable this plugin, it will not render the microformats. For version 2.4.1 this is using the same code used for static 
+rendering but future enhancements are planned.
+
 = Version 2.2.3 =
 The Micropub plugin will no longer store published, updated, summary, or name options. These will be derived from the WordPress post properties they are mapped to and returned on query.
 
@@ -229,6 +232,7 @@ into markdown and saved to readme.md.
 * Remove settings page as no more settings.
 * Bump minimum PHP version to PHP7.2
 * Require IndieAuth plugin
+* Switch to dynamic from static rendering on posts...markup will no longer be placed inside the content block but dynamically added.
 
 = 2.3.3 (2023-03-10) =
 * Stop including visible text in reply contexts since they go inside since they go inside e-content, which webmention recipients use as the reply text.

--- a/tests/test_endpoint.php
+++ b/tests/test_endpoint.php
@@ -36,7 +36,7 @@ class Micropub_Endpoint_Test extends Micropub_UnitTestCase {
 			'latitude'  => array( '42.361' ),
 			'longitude' => array( '-71.092' ),
 			'altitude'  => array( '25000' ),
-			'accuracy'  => array( '25000' )
+			'accuracy'  => array( '25000' ),
 		),
 	);
 
@@ -180,7 +180,7 @@ class Micropub_Endpoint_Test extends Micropub_UnitTestCase {
 		$this->assertFalse( has_post_format( $post ) );
 		$this->assertEquals( static::$author_id, $post->post_author, 'Post Author' );
 		// check that HTML in content is sanitized
-		$this->assertEquals( "<div class=\"e-content\">\nmy&lt;br&gt;content\n</div>", $post->post_content );
+		$this->assertEquals( "my&lt;br&gt;content", $post->post_content );
 		$this->assertEquals( 'my_slug', $post->post_name );
 		$this->assertEquals( 'my name', $post->post_title );
 		$this->assertEquals( 'my summary', $post->post_excerpt );
@@ -193,7 +193,7 @@ class Micropub_Endpoint_Test extends Micropub_UnitTestCase {
 		$source = $this->query_source( $post->ID );
 		$input['properties']['location'] = static::$geo;
 		$input = $this->remove_mp_properties( $input );
-		$this->assertEquals( $input, $source, wp_json_encode( $source ) );
+		$this->assertEquals( $input, $source, wp_json_encode( array( 'source' => $source, 'input' => $input ) ) );
 		return $post;
 	}
 
@@ -410,9 +410,7 @@ class Micropub_Endpoint_Test extends Micropub_UnitTestCase {
 		$post = get_post( $post_id );
 		// updated
 		$expected_content = <<<EOF
-<div class="e-content">
 new&lt;br&gt;content
-</div>
 EOF;
 		$this->assertEquals( $expected_content, $post->post_content );
 		// added


### PR DESCRIPTION
This is an intermediate step to add dynamic rendering. It keeps pre-2.4.0 posts using the static rendering, but everything new, that has the version tag within the Micropub auth response would use dynamic rendering unless either the Post Kinds plugin is enabled or some other unknown plugin changes the micropub_dynamic_render to true.

The only other plugin that amends the post content is @janboddez 's IndieBlocks, which converts the incoming Micropub content to blocks.

If this solution gets positive feedback as a solution my next step will be to enhance the rendering code to address all open issues. The idea being that this will render a simplified version of the data, Post Kinds will take that over if it is enabled, as will Indieblocks or a theme by removing the dynamic render filter or adding to the new filter.