### PR TITLE
Add a WordPress.org Plugin Repo Icon

### DIFF
--- a/.wordpress-org/icon.svg
+++ b/.wordpress-org/icon.svg
@@ -1,0 +1,4 @@
+<svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192">
+  <title>Micropub</title>
+  <path fill="#13b919" fill-rule="evenodd" d="M126 16a54 54 0 0 1 6 107.7V80.4a12 12 0 1 0-12 0V172a4 4 0 0 1-4 4H72V80.4a12 12 0 1 0-12 0V176H16a4 4 0 0 1-4-4V70a54 54 0 0 1 84-45 54 54 0 0 1 30-9Z"/>
+</svg>


### PR DESCRIPTION
See: https://developer.wordpress.org/plugins/wordpress-org/plugin-assets/#plugin-icons