### PR TITLE
Add npm and github-actions to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,14 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "composer" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "daily"

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -27,6 +27,8 @@ jobs:
           extensions: mysql
       - name: Install Composer dependencies for PHP
         uses: "ramsey/composer-install@v2"
+      - name: Install SVN
+        run: sudo apt-get update && sudo apt-get install -y subversion
       - name: Setup Test Environment
         run: composer setup-local-tests
       - name: Unit Testing


### PR DESCRIPTION
## Summary

Extends Dependabot configuration to monitor additional package ecosystems:

- **npm**: Monitors `package.json` dependencies
- **github-actions**: Monitors GitHub Actions workflow dependencies

This ensures all dependencies are kept up to date automatically.