### PR TITLE
Fix q=source to return valid MF2 JSON for all properties

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -325,6 +325,15 @@ if ( ! function_exists( 'micropub_get_mf2' ) ) {
 			if ( 'mf2_type' === $field ) {
 				$mf2['type'] = $val;
 			} elseif ( 'mf2_' === substr( $field, 0, 4 ) ) {
+				// Ensure property values are always arrays per MF2 spec.
+				// Skip empty strings as they indicate unset properties.
+				if ( '' === $val ) {
+					continue;
+				}
+				// Wrap non-array values in an array.
+				if ( ! is_array( $val ) ) {
+					$val = array( $val );
+				}
 				$mf2['properties'][ substr( $field, 4 ) ] = $val;
 			}
 		}

--- a/tests/test_functions.php
+++ b/tests/test_functions.php
@@ -26,4 +26,47 @@ class MicropubFunctionsTest extends WP_UnitTestCase {
 			)
 		);
 	}
+
+	function test_micropub_get_mf2_skips_empty_string_properties() {
+		$post_id = $this->factory->post->create();
+
+		// Add an empty string property (simulates unset property).
+		update_post_meta( $post_id, 'mf2_location', '' );
+		// Add a valid property.
+		update_post_meta( $post_id, 'mf2_category', array( 'test' ) );
+
+		$mf2 = micropub_get_mf2( $post_id );
+
+		// Empty string property should be skipped.
+		$this->assertArrayNotHasKey( 'location', $mf2['properties'] );
+		// Valid property should exist.
+		$this->assertArrayHasKey( 'category', $mf2['properties'] );
+	}
+
+	function test_micropub_get_mf2_wraps_non_array_values() {
+		$post_id = $this->factory->post->create();
+
+		// Add a non-array property value (string).
+		update_post_meta( $post_id, 'mf2_syndication', 'https://twitter.com/example/123' );
+
+		$mf2 = micropub_get_mf2( $post_id );
+
+		// Property value should be wrapped in an array.
+		$this->assertIsArray( $mf2['properties']['syndication'] );
+		$this->assertEquals( array( 'https://twitter.com/example/123' ), $mf2['properties']['syndication'] );
+	}
+
+	function test_micropub_get_mf2_preserves_array_values() {
+		$post_id = $this->factory->post->create();
+
+		// Add an array property value.
+		$categories = array( 'tech', 'indieweb' );
+		update_post_meta( $post_id, 'mf2_category', $categories );
+
+		$mf2 = micropub_get_mf2( $post_id );
+
+		// Property value should remain as array.
+		$this->assertIsArray( $mf2['properties']['category'] );
+		$this->assertEquals( $categories, $mf2['properties']['category'] );
+	}
 }


### PR DESCRIPTION
## Summary
- Ensures all MF2 property values are arrays as required by the MF2 spec
- Skips empty string values which indicate unset properties
- Wraps non-array values in arrays

Fixes #242