### PR TITLE
Return errors from wp_insert_post / wp_update_post failures

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -299,7 +299,7 @@ if ( ! function_exists( 'micropub_wp_error' ) ) {
 	function micropub_wp_error( $error ) {
 		if ( is_wp_error( $error ) ) {
 			$data   = $error->get_error_data();
-			$status = isset( $data['status'] ) ? $data['status'] : 200;
+			$status = isset( $data['status'] ) ? $data['status'] : 400;
 			if ( is_array( $data ) ) {
 				unset( $data['status'] );
 			}

--- a/includes/rest/class-endpoint-controller.php
+++ b/includes/rest/class-endpoint-controller.php
@@ -522,6 +522,11 @@ class Endpoint_Controller extends \WP_REST_Controller {
 		}
 
 		$this->insert_post( $args );
+
+		if ( \is_micropub_error( $args['ID'] ) ) {
+			return $args['ID'];
+		}
+
 		$this->default_file_handler( $args['ID'] );
 
 		return $args;
@@ -640,6 +645,11 @@ class Endpoint_Controller extends \WP_REST_Controller {
 		}
 
 		$this->update_post( $args );
+
+		if ( \is_micropub_error( $args['ID'] ) ) {
+			return $args['ID'];
+		}
+
 		$this->default_file_handler( $post_id );
 
 		return $args;

--- a/tests/phpunit/tests/class-test-endpoint.php
+++ b/tests/phpunit/tests/class-test-endpoint.php
@@ -231,6 +231,25 @@ class Micropub_Endpoint_Test extends Micropub_UnitTestCase {
 		self::check( $response, 403, 'insufficient_scope' );
 	}
 
+	public function test_create_returns_error_when_wp_insert_post_fails() {
+		// Force wp_insert_post to return a WP_Error with the empty-content
+		// code, mimicking the situation reported in issue #319.
+		add_filter( 'wp_insert_post_empty_content', '__return_true' );
+
+		$input    = array(
+			'h'           => 'entry',
+			'repost-of'   => 'https://example.com/post',
+			'post-status' => 'draft',
+		);
+		$response = $this->dispatch( self::create_form_request( $input ), static::$author_id );
+
+		remove_filter( 'wp_insert_post_empty_content', '__return_true' );
+
+		// The response must surface the error (not silently return 201 with the
+		// error nested inside the body).
+		self::check( $response, 400, 'empty_content' );
+	}
+
 	public function test_form_to_json_encode() {
 		$controller = new \Micropub\Rest\Endpoint_Controller();
 		$output     = $controller->form_to_json( static::$post );


### PR DESCRIPTION
## Summary

Fixes #319.

When `wp_insert_post` or `wp_update_post` returned a `WP_Error`, `check_error()` wrapped it as a Micropub `Error` and stored it in `$args['ID']`, but `handle_create()` / `handle_update()` returned the `$args` array as if the operation had succeeded. The endpoint then responded with HTTP 201 and a body that included the error nested inside the `ID` field, plus `post_url: false` and `Location: false`.

- Propagate the Micropub error from `handle_create()` and `handle_update()` when insertion fails, so `create_item()` returns a proper error response.
- Change the default status in `micropub_wp_error()` from 200 to 400. A `WP_Error` always indicates failure, so a 200 default never made sense; this also surfaces the correct status for `wp_insert_post`'s built-in errors (like `empty_content`) which carry no `status` data.

## Test plan

- [x] New regression test `test_create_returns_error_when_wp_insert_post_fails` reproduces the exact scenario from #319 (uses the `wp_insert_post_empty_content` filter to force the error). Fails on `trunk` (returns 201), passes with the fix (returns 400 with `error: empty_content`).
- [x] Full PHPUnit suite passes (86 tests, 337 assertions).
- [x] PHPCS clean on changed files.