### PR TITLE
Release 2.5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ npm-debug.log
 package-lock.json
 /.data
 .DS_Store
+.phpunit.result.cache

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,6 @@
 {
 	"core": null,
-	"plugins": [ "." ],
+	"plugins": [ "https://downloads.wordpress.org/plugin/indieauth.zip", "." ],
 	"env": {
 		"tests": {
 			"config": {

--- a/micropub.php
+++ b/micropub.php
@@ -12,14 +12,14 @@
  * Text Domain: micropub
  * License: CC0
  * License URI: http://creativecommons.org/publicdomain/zero/1.0/
- * Version: 2.5.0
+ * Version: 2.5.1
  *
  * @package Micropub
  */
 
 namespace Micropub;
 
-\define( 'MICROPUB_PLUGIN_VERSION', '2.5.0' );
+\define( 'MICROPUB_PLUGIN_VERSION', '2.5.1' );
 
 \defined( 'MICROPUB_NAMESPACE' ) || \define( 'MICROPUB_NAMESPACE', 'micropub/1.0' );
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 - Tags: micropub, publish, indieweb, microformats
 - Requires at least: 4.9.9
 - Tested up to: 7.0
-- Stable tag: 2.5.0
+- Stable tag: 2.5.1
 - Requires PHP: 7.2
 - License: CC0
 - License URI: http://creativecommons.org/publicdomain/zero/1.0/
@@ -72,6 +72,10 @@ These configuration options can be enabled by adding them to your wp-config.php:
 ## Changelog
 
 Project and support maintained on GitHub at [indieweb/wordpress-micropub](https://github.com/indieweb/wordpress-micropub).
+
+### 2.5.1
+
+* Fix error responses for failed post inserts and updates, returning the proper HTTP status code instead of a success response
 
 ### 2.5.0
 


### PR DESCRIPTION
## Summary

- Bump version to 2.5.1
- Add changelog entry for the error-response fix from #320 (fixes #319), the only user-facing change since 2.5.0
- Install IndieAuth in wp-env: WordPress now enforces the `Requires Plugins` header, so `wp-env start` failed to activate Micropub without it
- Ignore `.phpunit.result.cache`

## Test plan

- [ ] Verify plugin shows version 2.5.1 on the plugins page
- [ ] Verify a failed `wp_insert_post`/`wp_update_post` returns an error status instead of HTTP 201 (covered by unit tests)
- [ ] `composer lint` passes
- [ ] PHPUnit suite passes (86 tests, 337 assertions, verified locally against WordPress 7.0)
- [ ] `wp-env start` activates IndieAuth and Micropub

## Note

`composer test:wp-env` currently fails on WordPress 7.0 independent of this PR: the tests hard-code `http://example.org/?p=N` URLs while wp-env sets `WP_HOME=http://localhost:8989`, and WP 7.0 moved the host check in `url_to_postid()` before the `?p=N` shortcut. Fix (replacing hard-coded URLs with `home_url()`) is left for a follow-up PR.