### PR TITLE
Detect IndieAuth via the INDIEAUTH_PLUGIN_VERSION constant

### DIFF
--- a/micropub.php
+++ b/micropub.php
@@ -41,7 +41,7 @@ require_once MICROPUB_PLUGIN_DIR . 'includes/functions.php';
 // Compatibility Functions with Newer WordPress Versions.
 require_once MICROPUB_PLUGIN_DIR . 'includes/compat-functions.php';
 
-if ( \class_exists( \IndieAuth\IndieAuth::class ) ) {
+if ( \defined( 'INDIEAUTH_PLUGIN_VERSION' ) ) {
 	\add_action( 'plugins_loaded', array( Micropub::get_instance(), 'init' ) );
 } else {
 	\add_action( 'admin_notices', __NAMESPACE__ . '\indieauth_not_installed_notice' );

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,10 @@ These configuration options can be enabled by adding them to your wp-config.php:
 
 Project and support maintained on GitHub at [indieweb/wordpress-micropub](https://github.com/indieweb/wordpress-micropub).
 
+### Unreleased
+
+* Detect the IndieAuth plugin via the `INDIEAUTH_PLUGIN_VERSION` constant instead of a class check, which avoids coupling to IndieAuth's class names (indieweb/wordpress-indieauth#319) and requires IndieAuth 4.7.0 or later
+
 ### 2.5.1
 
 * Fix error responses for failed post inserts and updates, returning the proper HTTP status code instead of a success response

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -12,7 +12,8 @@ if ( false !== $_phpunit_polyfills_path ) {
 	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $_phpunit_polyfills_path );
 }
 
-require __DIR__ . '/includes/class-indieauth-plugin.php';
+// Simulate an active IndieAuth plugin (4.7.0+ defines this constant).
+define( 'INDIEAUTH_PLUGIN_VERSION', '4.7.0' );
 
 define( 'DIR_MEDIATESTDATA', __DIR__ . '/data' );
 

--- a/tests/phpunit/includes/class-indieauth-plugin.php
+++ b/tests/phpunit/includes/class-indieauth-plugin.php
@@ -1,6 +1,0 @@
-<?php
-
-namespace IndieAuth;
-
-class IndieAuth {
-}


### PR DESCRIPTION
## Problem

Micropub gates its whole initialization on an IndieAuth class check. That coupling to IndieAuth's internal class names broke once already, when IndieAuth 4.7.0 namespaced its classes and the `class_exists( 'IndieAuth_Plugin' )` check silently disabled Micropub (indieweb/wordpress-indieauth#319). Trunk currently checks `\IndieAuth\IndieAuth::class`, which would break again on any future rename and triggers an autoload just for feature detection.

## Solution

Check `\defined( 'INDIEAUTH_PLUGIN_VERSION' )` instead. The constant exists since IndieAuth 4.7.0 — the same effective requirement as trunk's namespaced class check — is part of IndieAuth's stable public surface, and is cheaper than a class check (no autoloader involvement). It also enables version comparisons later if ever needed.

The test bootstrap now defines the constant instead of shipping a mock IndieAuth class.

## Verification

- TDD: switched the bootstrap to the constant first — 54 tests failed against the class-based gate (including the exact `404 vs 403` symptom from #319), then the gate change brought the suite back to baseline.
- phpcs clean; full CI matrix (PHP 7.4/8.3/8.5) green.

https://claude.ai/code/session_0126gxnmr2SMc4X4J1Y6yf71