### PR TITLE
Release 2.5.2

### DIFF
--- a/micropub.php
+++ b/micropub.php
@@ -12,14 +12,14 @@
  * Text Domain: micropub
  * License: CC0
  * License URI: http://creativecommons.org/publicdomain/zero/1.0/
- * Version: 2.5.1
+ * Version: 2.5.2
  *
  * @package Micropub
  */
 
 namespace Micropub;
 
-\define( 'MICROPUB_PLUGIN_VERSION', '2.5.1' );
+\define( 'MICROPUB_PLUGIN_VERSION', '2.5.2' );
 
 \defined( 'MICROPUB_NAMESPACE' ) || \define( 'MICROPUB_NAMESPACE', 'micropub/1.0' );
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 - Tags: micropub, publish, indieweb, microformats
 - Requires at least: 4.9.9
 - Tested up to: 7.0
-- Stable tag: 2.5.1
+- Stable tag: 2.5.2
 - Requires PHP: 7.2
 - License: CC0
 - License URI: http://creativecommons.org/publicdomain/zero/1.0/
@@ -73,9 +73,10 @@ These configuration options can be enabled by adding them to your wp-config.php:
 
 Project and support maintained on GitHub at [indieweb/wordpress-micropub](https://github.com/indieweb/wordpress-micropub).
 
-### Unreleased
+### 2.5.2
 
 * Detect the IndieAuth plugin via the `INDIEAUTH_PLUGIN_VERSION` constant instead of a class check, which avoids coupling to IndieAuth's class names (indieweb/wordpress-indieauth#319) and requires IndieAuth 4.7.0 or later
+* Fix a crash in the post preview when a post has no valid published or modified date
 
 ### 2.5.1
 


### PR DESCRIPTION
## Summary

- Bump version to 2.5.2
- Rename the "Unreleased" changelog section to 2.5.2 and add an entry for the preview-crash date fix from #326

Changes since 2.5.1:

- Detect the IndieAuth plugin via the `INDIEAUTH_PLUGIN_VERSION` constant instead of a class check (#325, #327)
- Fix a crash in the post preview when a post has no valid published or modified date (#326)

## Test plan

- [ ] Verify plugin shows version 2.5.2 on the plugins page
- [ ] `composer lint` passes
- [ ] PHPUnit suite passes